### PR TITLE
docs: ADR on pausing lms user id backfill in the Credentials IDA

### DIFF
--- a/credentials/apps/core/docs/decisions/0001-pausing-lms-user-id-backfill.rst
+++ b/credentials/apps/core/docs/decisions/0001-pausing-lms-user-id-backfill.rst
@@ -1,0 +1,32 @@
+LMS User Id Backfill in the Credentials IDA
+===========================================
+
+Status
+------
+Accepted
+
+Background
+----------
+As stated in OEP-32_, the LMS's user id should be the unique identifier for users in the Open edX ecosystem. Recently, support for syncing the LMS's user id was added to the Credentials IDA.
+
+Now, when API calls from the LMS are processed by the Credentials IDA, we will extract and sync the LMS user id data and with the Credentials user record (in the `CORE_USER` table).
+
+We intended to provide a way (or at least a template that could be adapted) to backfill the missing user id values from the LMS using the `sync_lms_user_ids` management command.
+
+However, we ran into numerous (internal, environment and user permission) issues while testing the management command.
+
+Today, there is no process, event, or feature in the Credentials IDA that requires access to the user's LMS User Id data.
+
+.. _OEP-32: https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0032-arch-unique-identifier-for-users.html
+
+Decision
+--------
+
+The LMS user id is not currently utilized in the Credentials IDA and we have decided to table the backfill work.
+
+We have decided *not* to remove the `sync_lms_user_ids` management command at this time.
+
+Consequences
+------------
+
+If there is a desire to use or access the LMS user id from the Credentials IDA, this work will need to be finished.

--- a/credentials/apps/core/management/commands/sync_lms_user_ids.py
+++ b/credentials/apps/core/management/commands/sync_lms_user_ids.py
@@ -1,5 +1,9 @@
 """
 Django management command to load the `lms_user_id` column from historical user data.
+
+******
+Please see the `0001-pausing-lms-user-id-backfill` ADR before attempting to use this management command.
+******
 """
 
 
@@ -40,6 +44,13 @@ class Command(BaseCommand):
         ) u
 
     This management command assumes the data will be accessible from an AWS S3 bucket hosting the exported CSV.
+
+    The user executing this management command requires specific SQL permissions:
+        - CREATE
+        - UPDATE
+        - DROP
+        - INDEX
+        - LOAD FROM S3
 
     This commands capabilities are split into multiple 'stages' in order to allow time for manual verifications before
     and after syncing the LMS user data:


### PR DESCRIPTION
[MICROBA-1465]
- adds an ADR on why we have paused the LMS user id backfill in the Credentials IDA
- updates the `sync_lms_user_ids` management command with additional info on SQL grants/permissions required to run the command