### PR TITLE
chore: Update `credentials-themes` to v0.1.101

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -48,4 +48,4 @@ xss-utils
 
 
 # TODO Install in configuration
-git+https://github.com/edx/credentials-themes.git@0.1.97#egg=edx_credentials_themes==0.1.97
+git+https://github.com/edx/credentials-themes.git@0.1.101#egg=edx_credentials_themes==0.1.101


### PR DESCRIPTION
* Update the version of the `credentials-themes` package to 0.1.101 in the credentials IDA.