### PR TITLE
chore: adjust `upgrade requirements` job to run on Monday

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,8 @@ name: Upgrade Requirements
 
 on:
   schedule:
-     - cron: "15 13 * * 4"
+     # will start the job at 13:15 UTC (09:15 EST) every Tuesday
+     - cron: "15 13 * * 2"
   workflow_dispatch:
      inputs:
        branch:


### PR DESCRIPTION
* Adjusts the cron schedule of the `upgrade-python-requirements` job to run on Mondays.