### PR TITLE
feat: Add cookie monitoring middleware (and other standard monitors)

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -78,8 +78,11 @@ INSTALLED_APPS += PROJECT_APPS
 
 MIDDLEWARE = (
     "corsheaders.middleware.CorsMiddleware",
-    "edx_django_utils.monitoring.DeploymentMonitoringMiddleware",
     "edx_django_utils.cache.middleware.RequestCacheMiddleware",
+    "edx_django_utils.monitoring.DeploymentMonitoringMiddleware",
+    "edx_django_utils.monitoring.CookieMonitoringMiddleware",
+    "edx_django_utils.monitoring.CachedCustomMonitoringMiddleware",
+    "edx_django_utils.monitoring.MonitoringMemoryMiddleware",
     "edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",


### PR DESCRIPTION
- Add cookie[1], custom metrics, and memory usage middlewares.
- Reorder RequestCacheMiddleware to top of EDU list to match documented
  preferred order.

[1] https://2u-internal.atlassian.net/browse/ARCHBOM-2072
"Add CookieMonitoringMiddleware to other IDAs"