### PR TITLE
chore: add support tools devstack link in credentials CORS whitelist

### DIFF
--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -66,7 +66,7 @@ BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = os.environ.get(
     "http://edx.devstack.lms:18000/oauth2",
 )
 
-CORS_ORIGIN_WHITELIST = ("http://localhost:1990",)
+CORS_ORIGIN_WHITELIST = ("http://localhost:1990", "http://localhost:18450")
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = str2bool(os.environ.get("SOCIAL_AUTH_REDIRECT_IS_HTTPS", False))
 


### PR DESCRIPTION
- Allow edx/frontend-app-support-tools in edx/credentials for local devstack
Link to associated ticket: [PROD-2569](https://openedx.atlassian.net/browse/PROD-2569)
Link to edx-internal repo PR that [validates this addition](https://github.com/edx/edx-internal/pull/6496)