### PR TITLE
fix: download records without Segment setup

### DIFF
--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -1120,6 +1120,7 @@ class ProgramSendTests(SiteMixin, TestCase):
         self.assertEqual(user_credit_pathway.status, UserCreditPathwayStatus.SENT)
 
 
+@ddt.ddt
 class ProgramRecordCsvViewTests(SiteMixin, TestCase):
     MOCK_USER_DATA = {
         "username": "test-user",
@@ -1178,15 +1179,22 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
         )
         self.assertEqual(404, response.status_code)
 
+    @ddt.data(True, False)
     @patch("credentials.apps.records.views.SegmentClient", autospec=True)
     @patch("credentials.apps.records.views.SegmentClient.track", autospec=True)
-    def tests_creates_csv(self, segment_client, track):  # pylint: disable=unused-argument
-        """Verify that the csv parses and contains all of the necessary titles/headers"""
+    def tests_creates_csv(self, segment_should_be_used, segment_client, track):  # pylint: disable=unused-argument
+        """
+        Verify that the csv parses and contains all of the necessary titles/headers.
+        """
+        if segment_should_be_used:
+            self.site_configuration.segment_key = "the_key_to_the_apartment_where_the_money_will_be"
+            self.site_configuration.save()
         response = self.client.get(
             reverse("records:program_record_csv", kwargs={"uuid": self.program_cert_record.uuid.hex})
         )
+        self.assertEqual(bool(self.site_configuration.segment_key), segment_should_be_used)
         self.assertEqual(200, response.status_code)
-        self.assertTrue(track.called)
+        self.assertEqual(track.called, segment_should_be_used)
         content = response.content.decode("utf-8")
         csv_reader = csv.reader(io.StringIO(content))
         body = list(csv_reader)

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -314,14 +314,15 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
             super(ProgramRecordCsvView.SegmentHttpResponse, self).__init__(*args, **kwargs)
 
         def close(self):
-            self.segment_client.track(
-                self.anonymous_id, event=self.event, properties=self.properties, context=self.context
-            )
+            if self.segment_client:
+                self.segment_client.track(
+                    self.anonymous_id, event=self.event, properties=self.properties, context=self.context
+                )
             super(ProgramRecordCsvView.SegmentHttpResponse, self).close()
 
     def get(self, request, *args, **kwargs):
         site_configuration = request.site.siteconfiguration
-        segment_client = SegmentClient(write_key=site_configuration.segment_key)
+        segment_client = None
 
         program_cert_record = get_object_or_404(ProgramCertRecord, uuid=kwargs.get("uuid"))
         record = get_record_data(
@@ -362,12 +363,14 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
         # 'ajs_anonymous_id' cookie not existing in the request.
         anonymous_id = request.COOKIES.get("ajs_anonymous_id", str(uuid4()))
 
-        segment_client.track(
-            anonymous_id,
-            context=context,
-            event="edx.bi.credentials.program_record.download_started",
-            properties=properties,
-        )
+        if segment_key := site_configuration.segment_key:
+            segment_client = SegmentClient(write_key=segment_key)
+            segment_client.track(
+                request.COOKIES.get("ajs_anonymous_id"),
+                context=context,
+                event="edx.bi.credentials.program_record.download_started",
+                properties=properties,
+            )
 
         string_io = io.StringIO()
         writer = csv.writer(string_io, quoting=csv.QUOTE_ALL)


### PR DESCRIPTION
Fix the download records functionality when Segment is not used.

The user is getting the error if the platform has no Segment settings.

**Preconditions**
- The `segment_key` setting in the credentials site configurations is empty

**STR**
1. Go to the records page, click "Share" and copy the sharing URL:
<img width="1426" alt="Screenshot 2022-08-19 at 15 11 28" src="https://user-images.githubusercontent.com/47273130/185616704-467602de-d153-434a-8d0c-734d85dcb23b.png">
2. Open the copied URL in the new tab or incognito window and click "Download":
<img width="1426" alt="Screenshot 2022-08-19 at 15 12 48" src="https://user-images.githubusercontent.com/47273130/185616850-5dd5825d-da7a-41a9-93b8-4fe899535f3a.png">

**Actual Result**
User see the 500 error:
<img width="1160" alt="Screenshot 2022-08-19 at 15 20 42" src="https://user-images.githubusercontent.com/47273130/185617136-43a1ab1f-50df-42b7-96cf-0c00d4b73bae.png">
Error logs:
```
Traceback (most recent call last):
File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
response = get_response(request)
File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/views/generic/base.py", line 70, in view
return self.dispatch(request, *args, **kwargs)
File "/edx/app/credentials/credentials/credentials/apps/records/views.py", line 56, in dispatch
return super().dispatch(request, *args, **kwargs)
File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/django/views/generic/base.py", line 98, in dispatch
return handler(request, *args, **kwargs)
File "/edx/app/credentials/credentials/credentials/apps/records/views.py", line 478, in get
segment_client = SegmentClient(write_key=site_configuration.segment_key)
File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/analytics/client.py", line 60, in init
require('write_key', write_key, string_types)
File "/edx/app/credentials/venvs/credentials/lib/python3.8/site-packages/analytics/client.py", line 325, in require
raise AssertionError(msg)
AssertionError: write_key must have (<class 'str'>,), got: None
```

**Expecting Result**
The user (or anonymous user) can download the CSV report.

Notes:
- Segment key is not the mandatory setting in the credentials site configuration

