### PR TITLE
build: Adding django linter for migrations.

### DIFF
--- a/.github/workflows/migration-linter.yml
+++ b/.github/workflows/migration-linter.yml
@@ -1,0 +1,34 @@
+name: Migration Linter CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  migrations-linting:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get commits data
+        run: |
+          echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
+
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+
+      - name: Check commits
+        run: git log --oneline
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+
+      - name: Install Dependencies
+        run: make requirements
+
+      - name: Run migrations linting
+        run: |
+          python manage.py lintmigrations --settings=credentials.settings.test --project-root-path=. --git-commit-id `git rev-parse HEAD~${{ github.event.pull_request.commits }}` --warnings-as-errors

--- a/.github/workflows/migrations-mysql8-check.yml
+++ b/.github/workflows/migrations-mysql8-check.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         pip install -r requirements/pip_tools.txt
+        pip install -r requirements/test.txt
         pip install -r requirements/production.txt
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient

--- a/Makefile
+++ b/Makefile
@@ -201,5 +201,9 @@ quality_and_translations_tests_suite: build_test_image
 unit_tests_suite: build_test_image
 	docker run -e "TERM=xterm-256color" -v /edx/app/credentials/node_modules/ -v `pwd`:/edx/app/credentials/ credentials:local bash -c 'cd /edx/app/credentials/ && make static && make tests && make coverage'
 
+
+migration_linter_ci:
+	python manage.py lintmigrations --settings=credentials.settings.test --git-commit-id `git rev-parse origin/master`
+
 docs:
 	tox -e docs

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -262,7 +262,7 @@ class UserGradeSerializer(serializers.ModelSerializer):
         # turn off validation, it only tries to complain about unique_together when updating existing objects
         validators = []
 
-    def is_valid(self, *, raise_exception=False):
+    def is_valid(self, *, raise_exception=False):  # pylint: disable=arguments-differ
         # The LMS sometimes gives us None for the letter grade for some reason. But since the model doesn't take null,
         # just convert it into an empty string instead.
         if self.initial_data.get("letter_grade", "") is None:

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -6,6 +6,7 @@ from credentials.settings.utils import get_logger_config
 
 INSTALLED_APPS += [
     "credentials.apps.edx_credentials_extensions",
+    "django_migration_linter",
 ]
 
 LOGGING = get_logger_config(debug=False, dev_env=True, local_loglevel="DEBUG")

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -8,6 +8,10 @@ analytics-python==1.4.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
+appdirs==1.4.4
+    # via
+    #   -r requirements/dev.txt
+    #   django-migration-linter
 asgiref==3.5.2
     # via
     #   -r requirements/dev.txt
@@ -42,11 +46,11 @@ bleach==5.0.1
     #   -r requirements/production.txt
 bok-choy==1.1.1
     # via -r requirements/dev.txt
-boto3==1.24.85
+boto3==1.24.87
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.27.85
+botocore==1.27.87
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -141,6 +145,7 @@ django==3.2.16
     #   django-extensions
     #   django-filter
     #   django-hijack
+    #   django-migration-linter
     #   django-ses
     #   django-statici18n
     #   django-storages
@@ -187,6 +192,8 @@ django-hijack==2.3.0
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
+django-migration-linter==4.1.0
+    # via -r requirements/dev.txt
 django-ratelimit==3.0.1
     # via
     #   -r requirements/dev.txt
@@ -722,6 +729,10 @@ texttable==1.6.4
     # via
     #   -r requirements/dev.txt
     #   docker-compose
+toml==0.10.2
+    # via
+    #   -r requirements/dev.txt
+    #   django-migration-linter
 tomli==2.0.1
     # via
     #   -r requirements/dev.txt

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,6 +6,10 @@
 #
 analytics-python==1.4.0
     # via -r requirements/test.txt
+appdirs==1.4.4
+    # via
+    #   -r requirements/test.txt
+    #   django-migration-linter
 asgiref==3.5.2
     # via
     #   -r requirements/test.txt
@@ -111,6 +115,7 @@ django==3.2.16
     #   django-extensions
     #   django-filter
     #   django-hijack
+    #   django-migration-linter
     #   django-statici18n
     #   django-storages
     #   djangorestframework
@@ -147,6 +152,8 @@ django-hijack==2.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
+django-migration-linter==4.1.0
+    # via -r requirements/test.txt
 django-ratelimit==3.0.1
     # via -r requirements/test.txt
 django-rest-swagger==2.2.0
@@ -555,6 +562,10 @@ text-unidecode==1.3
     #   python-slugify
 texttable==1.6.4
     # via docker-compose
+toml==0.10.2
+    # via
+    #   -r requirements/test.txt
+    #   django-migration-linter
 tomli==2.0.1
     # via
     #   -r requirements/test.txt

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -12,7 +12,7 @@ packaging==21.3
     # via build
 pep517==0.13.0
     # via build
-pip-tools==6.8.0
+pip-tools==6.9.0
     # via -r requirements/pip_tools.in
 pyparsing==3.0.9
     # via packaging

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,9 +20,9 @@ backoff==1.10.0
     #   analytics-python
 bleach==5.0.1
     # via -r requirements/base.txt
-boto3==1.24.85
+boto3==1.24.87
     # via django-ses
-botocore==1.27.85
+botocore==1.27.87
     # via
     #   boto3
     #   s3transfer

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -18,6 +18,7 @@ bok-choy
 code-annotations          # provides commands used by the pii_check make target
 coverage
 ddt
+django-migration-linter
 edx-lint
 factory-boy
 httpretty

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,6 +6,8 @@
 #
 analytics-python==1.4.0
     # via -r requirements/base.txt
+appdirs==1.4.4
+    # via django-migration-linter
 asgiref==3.5.2
     # via
     #   -r requirements/base.txt
@@ -97,6 +99,7 @@ distlib==0.3.6
     #   django-extensions
     #   django-filter
     #   django-hijack
+    #   django-migration-linter
     #   django-statici18n
     #   django-storages
     #   djangorestframework
@@ -131,6 +134,8 @@ django-hijack==2.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
+django-migration-linter==4.1.0
+    # via -r requirements/test.in
 django-ratelimit==3.0.1
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
@@ -482,6 +487,8 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
+toml==0.10.2
+    # via django-migration-linter
 tomli==2.0.1
     # via
     #   black


### PR DESCRIPTION
### Description 
- POC PR to add `django-migration-linter` to test/inspect the migrations created in the PRs and identify the backwards incompatible migrations before they are merged to master.