### PR TITLE
fix: revert recent change to CourseGradeSerializer

### DIFF
--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -262,14 +262,13 @@ class UserGradeSerializer(serializers.ModelSerializer):
         # turn off validation, it only tries to complain about unique_together when updating existing objects
         validators = []
 
-    def to_internal_value(self, data):
+    def is_valid(self, *, raise_exception=False):
         # The LMS sometimes gives us None for the letter grade for some reason. But since the model doesn't take null,
         # just convert it into an empty string instead.
-        letter_grade = data.get("letter_grade", "")
-        if not letter_grade:
-            data["letter_grade"] = ""
+        if self.initial_data.get("letter_grade", "") is None:
+            self.initial_data["letter_grade"] = ""
 
-        return super().to_internal_value(data)
+        return super().is_valid(raise_exception=raise_exception)
 
     def create(self, validated_data):
         # If these next two are missing, the serializer will have already caught the error


### PR DESCRIPTION
In PR #1763, Django Rest Framework made a breaking change in a minor version release of their package. When attempting to fix this issue, I noticed some logic that was changing/updating data before validation in an overridden `is_valid` function. I made this change based on some reading I had done suggesting that this kind of data modification should be done in a dedicated Serializer Field class or by overriding the `to_internal_value` function in the Serializer class.

After making this change we were alerted to a number of errors occurring in the Credentials service. It looks like the data dict I was attempting to modify is immutable and can't be changed. Thus, I need to go back to the original implementation.