### PR TITLE
feat: redirect users to LR MFE records pages where appropriate

### DIFF
--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -241,7 +241,7 @@ def _get_shared_program_cert_record_data(program, user):
     except ProgramCertRecord.DoesNotExist:
         return None
     else:
-        return str(shared_program_record.uuid)
+        return str(shared_program_record.uuid.hex)
 
 
 def get_program_record_data(user, program_uuid, site, platform_name=None):

--- a/credentials/apps/records/tests/test_api.py
+++ b/credentials/apps/records/tests/test_api.py
@@ -210,7 +210,7 @@ class ApiTests(SiteMixin, TestCase):
         Test that verifies the functionality of the `_get_shared_program_cert_record_data` utility function.
         """
         result = _get_shared_program_cert_record_data(self.program, self.user)
-        assert result == str(self.shared_program_cert_record.uuid)
+        assert result == str(self.shared_program_cert_record.uuid.hex)
 
     def test_get_shared_program_cert_record_data_record_dne(self):
         """

--- a/credentials/apps/records/urls.py
+++ b/credentials/apps/records/urls.py
@@ -9,9 +9,11 @@ from . import views
 urlpatterns = [
     re_path(r"^$", views.RecordsView.as_view(), name="index"),
     re_path(r"^api/", include(("credentials.apps.records.rest_api.urls", "api"), namespace="api")),
+    # TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
     re_path(
         rf"^programs/{UUID_PATTERN}/$", views.ProgramRecordView.as_view(), {"is_public": False}, name="private_programs"
     ),
+    # NOTE: We need to _keep_ this to ensure shared public program records continue to work
     re_path(
         rf"^programs/shared/{UUID_PATTERN}/$",
         views.ProgramRecordView.as_view(),


### PR DESCRIPTION
[APER-1975]

It is possible for learners to generate a link to a public version of their program record(s) to allow external entities to view their progress. This is particularly important as we embed these links within messages that get shared via credit pathways. We wanted to ensure that these links are not broken when the default experience becomes the Learner Record MFE, so we will be redirecting requests to the legacy view to the Learner Record MFE.

* Implement a redirect when a public program record is being requested (and the Learner Record MFE is enabled)
* Implement a redirect when hitting the records index page (and the Learner Record MFE is enabled)
* Fix an issue with the shared program record UUID being returned with dashes (Credentials can't process UUIDs with dashes in the program record view)