### PR TITLE
docs: Add comments on legacy frontend components/classes that can be removed as part of issue #1722

### DIFF
--- a/credentials/static/components/Analytics.jsx
+++ b/credentials/static/components/Analytics.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 // Function that wraps analytics.track so that it can be also be called directly
 function trackEvent(name, properties) {
   // Only load the key if it has been injected into the page already

--- a/credentials/static/components/FoldingTable.jsx
+++ b/credentials/static/components/FoldingTable.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/credentials/static/components/MasqueradeBanner.jsx
+++ b/credentials/static/components/MasqueradeBanner.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';

--- a/credentials/static/components/MasqueradeBannerFactory.jsx
+++ b/credentials/static/components/MasqueradeBannerFactory.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/credentials/static/components/ProgramIcon.jsx
+++ b/credentials/static/components/ProgramIcon.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import PropTypes from 'prop-types';
 

--- a/credentials/static/components/ProgramRecord.jsx
+++ b/credentials/static/components/ProgramRecord.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import axios from 'axios';
 import PropTypes from 'prop-types';

--- a/credentials/static/components/ProgramRecordFactory.jsx
+++ b/credentials/static/components/ProgramRecordFactory.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/credentials/static/components/RecordsFactory.jsx
+++ b/credentials/static/components/RecordsFactory.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import ReactDOM from 'react-dom';
 

--- a/credentials/static/components/RecordsHelp.jsx
+++ b/credentials/static/components/RecordsHelp.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import React from 'react';
 import PropTypes from 'prop-types';
 import StringUtils from './Utils';

--- a/credentials/static/components/RecordsList.jsx
+++ b/credentials/static/components/RecordsList.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import PropTypes from 'prop-types';
 import React from 'react';
 

--- a/credentials/static/components/SendLearnerRecordModal.jsx
+++ b/credentials/static/components/SendLearnerRecordModal.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import 'core-js/features/promise'; // Needed to support Promises on legacy browsers
 import React from 'react';
 import PropTypes from 'prop-types';

--- a/credentials/static/components/ShareProgramRecordModal.jsx
+++ b/credentials/static/components/ShareProgramRecordModal.jsx
@@ -1,3 +1,4 @@
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 import 'core-js/features/promise'; // Needed to support Promises on legacy browsers
 import React from 'react';
 import axios from 'axios';

--- a/credentials/static/sass/_layouts.scss
+++ b/credentials/static/sass/_layouts.scss
@@ -202,6 +202,7 @@
 }
 
 
+// TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
 // FoldingTable
 .folding-table-big {
   display: none;

--- a/credentials/templates/_masquerade.html
+++ b/credentials/templates/_masquerade.html
@@ -1,3 +1,4 @@
+{# TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722 #}
 {% load hijack_tags %}
 {% load render_bundle from webpack_loader %}
 

--- a/credentials/templates/programs.html
+++ b/credentials/templates/programs.html
@@ -1,3 +1,4 @@
+{# TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722 #}
 {% extends 'base.html' %}
 {% load django_markup %}
 {% load html %}

--- a/credentials/templates/records.html
+++ b/credentials/templates/records.html
@@ -1,3 +1,4 @@
+{# TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722 #}
 {% extends 'base.html' %}
 {% load html %}
 {% load i18n %}


### PR DESCRIPTION


[APER-1975]

After releasing the Learner Record MFE we plan on starting removal of the legacy frontend components within the Credentials IDA. This PR just adds comments to the more obvious things which are clear for removal.