### PR TITLE
docs: [FC-0002] plugin extensions ADR

### DIFF
--- a/docs/decisions/0006-plugin-extensions.rst
+++ b/docs/decisions/0006-plugin-extensions.rst
@@ -11,7 +11,7 @@ Context
 -------
 
 More functionality is planned to be added to the Credentials service as a part of
-https://github.com/openedx/credentials/issues/1734 and https://github.com/openedx/credentials/issues/1736.
+`credentials/issues/1734`_ and `credentials/issues/1736`_.
 Credentials may benefit from adoption of the `Django App Plugin`_ functionality.
 It would provide additional possibilities to support many integrations with third-party
 services for credentials sharing, like digital credentials platforms, digital wallets,
@@ -19,7 +19,8 @@ credentials signing services, etc.
 
 For more information on plugins in particular, see the `Django Apps Plugin README`_.
 
-
+.. _`credentials/issues/1734`: https://github.com/openedx/credentials/issues/1734 
+.. _`credentials/issues/1736`: https://github.com/openedx/credentials/issues/1736 
 .. _Django App Plugin: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/README.rst
 .. _Django Apps Plugin README: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/README.rst
 

--- a/docs/decisions/0006-plugin-extensions.rst
+++ b/docs/decisions/0006-plugin-extensions.rst
@@ -1,0 +1,60 @@
+Django App Plugin extensions
+============================
+
+Status
+------
+
+Proposed
+
+
+Context
+-------
+
+More functionality is planned to be added to the Credentials service as a part of
+https://github.com/openedx/credentials/issues/1734 and https://github.com/openedx/credentials/issues/1736.
+Credentials may benefit from adoption of the `Django App Plugin`_ functionality.
+It would provide additional possibilities to support many integrations with third-party
+services for credentials sharing, like digital credentials platforms, digital wallets,
+credentials signing services, etc.
+
+For more information on plugins in particular, see the `Django Apps Plugin README`_.
+
+
+.. _Django App Plugin: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/README.rst
+.. _Django Apps Plugin README: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/README.rst
+
+
+Decision
+--------
+
+* Implement improved plugin support of Django apps in the Credentials service by adopting `edx_django_utils`_ module. Django apps plugins will support `overrides system`_ for core functionality.
+
+* Use plugin applications for future extension points and optional functionality for the Credentials service.
+
+* Create a version of `cookiecutter-django-app`_ for the Credentials, to easily create new plugin applications.
+
+
+.. _edx_django_utils: https://github.com/openedx/edx-django-utils
+.. _overrides system: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/pluggable_override.py#L11
+.. _cookiecutter-django-app: https://github.com/openedx/edx-cookiecutters/tree/master/cookiecutter-django-app
+
+Consequences
+------------
+
+* It will be easier to extend the Credentials service and implement new business cases without building a monolithic unit.
+
+* It will be possible to override the core functionality of the Credentials service for specific use cases without direct code modifications.
+
+* It will become easier to support Credentials system "upgradability".
+
+* It may introduce complexity for code discovery in case of implicit overrides and a lack of documentation on particular plugin functionality.
+
+Rejected Alternatives
+---------------------
+
+* Adding Django applications directly to credentials/apps.
+
+References
+----------
+
+The Open edX platform Django apps ADR 0014: https://github.com/openedx/edx-platform/blob/master/docs/decisions/0014-no-new-apps.rst

--- a/docs/decisions/0006-plugin-extensions.rst
+++ b/docs/decisions/0006-plugin-extensions.rst
@@ -58,3 +58,5 @@ References
 ----------
 
 The Open edX platform Django apps ADR 0014: https://github.com/openedx/edx-platform/blob/master/docs/decisions/0014-no-new-apps.rst
+
+How to enable plugins for an IDA: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/docs/how_tos/how_to_enable_plugins_for_an_ida.rst

--- a/docs/decisions/0006-plugin-extensions.rst
+++ b/docs/decisions/0006-plugin-extensions.rst
@@ -32,12 +32,8 @@ Decision
 
 * Use plugin applications for future extension points and optional functionality for the Credentials service.
 
-* Create a version of `cookiecutter-django-app`_ for the Credentials, to easily create new plugin applications.
-
-
 .. _edx_django_utils: https://github.com/openedx/edx-django-utils
 .. _overrides system: https://github.com/openedx/edx-django-utils/blob/master/edx_django_utils/plugins/pluggable_override.py#L11
-.. _cookiecutter-django-app: https://github.com/openedx/edx-cookiecutters/tree/master/cookiecutter-django-app
 
 Consequences
 ------------


### PR DESCRIPTION
In this ADR you will find a proposal to adopt plugin extensions system, initially implemented in the Open edX platform, but latter was extracted from it and now is ready for using by IDAs, ref. https://github.com/openedx/edx-django-utils/blob/master/docs/decisions/0002-extract-plugins-infrastructure-from-edx-platform.rst.

This ADR is proposed as a part of [FC-0002](https://openedx.atlassian.net/wiki/spaces/COMM/pages/3493822533/General+Design+for+Sharing+Open+edX+Credentials+-+FC-0002) General Design for Sharing Open edX Credentials

Ticket: https://github.com/openedx/credentials/issues/1735