### PR TITLE
chore: backport learner record redirection changes to Olive

### DIFF
--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -241,7 +241,7 @@ def _get_shared_program_cert_record_data(program, user):
     except ProgramCertRecord.DoesNotExist:
         return None
     else:
-        return str(shared_program_record.uuid)
+        return str(shared_program_record.uuid.hex)
 
 
 def get_program_record_data(user, program_uuid, site, platform_name=None):

--- a/credentials/apps/records/tests/test_api.py
+++ b/credentials/apps/records/tests/test_api.py
@@ -210,7 +210,7 @@ class ApiTests(SiteMixin, TestCase):
         Test that verifies the functionality of the `_get_shared_program_cert_record_data` utility function.
         """
         result = _get_shared_program_cert_record_data(self.program, self.user)
-        assert result == str(self.shared_program_cert_record.uuid)
+        assert result == str(self.shared_program_cert_record.uuid.hex)
 
     def test_get_shared_program_cert_record_data_record_dne(self):
         """

--- a/credentials/apps/records/urls.py
+++ b/credentials/apps/records/urls.py
@@ -9,9 +9,11 @@ from . import views
 urlpatterns = [
     re_path(r"^$", views.RecordsView.as_view(), name="index"),
     re_path(r"^api/", include(("credentials.apps.records.rest_api.urls", "api"), namespace="api")),
+    # TODO: We should be able to remove this as part of https://github.com/openedx/credentials/issues/1722
     re_path(
         rf"^programs/{UUID_PATTERN}/$", views.ProgramRecordView.as_view(), {"is_public": False}, name="private_programs"
     ),
+    # NOTE: We need to _keep_ this to ensure shared public program records continue to work
     re_path(
         rf"^programs/shared/{UUID_PATTERN}/$",
         views.ProgramRecordView.as_view(),


### PR DESCRIPTION
[APER-1975]

This change backports recent changes to the Credentials IDA supporting the Learner Record and Support Tools MFEs. The following changes have been cherry picked from the main branch:
- feat: redirect users to LR MFE records pages where appropriate (cherry picked from commit ecf6463d303e268d1fc251c37716719d524a48e6)