### PR TITLE
chore: add error logging to select_template calls

### DIFF
--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -107,9 +107,7 @@ class ThemeViewMixin:
         try:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
-            logger.error(
-                f"Could not select template in [{templates}] for theme "
-            )
+            logger.error(f"Could not select template in [{templates}] for theme ")
             raise
 
     def try_select_theme_template(self, templates):
@@ -119,9 +117,7 @@ class ThemeViewMixin:
         try:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
-            logger.error(
-                f"Could not find theme template in [{templates}]"
-            )
+            logger.error(f"Could not find theme template in [{templates}]")
             return ""
 
 

--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -104,7 +104,11 @@ class ThemeViewMixin:
         return template_names
 
     def select_theme_template(self, templates):
-        return select_template(self.add_theme_to_template_names(templates))
+        try:
+            return select_template(self.add_theme_to_template_names(templates))
+        except TemplateDoesNotExist:
+            logger.error(f"Could not select template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}" )
+            raise
 
     def try_select_theme_template(self, templates):
         """Select a template or return an empty string if the template doesn't exist.
@@ -113,6 +117,7 @@ class ThemeViewMixin:
         try:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
+            logger.error(f"Could not find theme template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}" )
             return ""
 
 

--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -107,7 +107,9 @@ class ThemeViewMixin:
         try:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
-            logger.error(f"Could not select template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}" )
+            logger.error(
+                f"Could not select template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}"
+            )
             raise
 
     def try_select_theme_template(self, templates):
@@ -117,7 +119,9 @@ class ThemeViewMixin:
         try:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
-            logger.error(f"Could not find theme template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}" )
+            logger.error(
+                f"Could not find theme template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}"
+            )
             return ""
 
 

--- a/credentials/apps/core/views.py
+++ b/credentials/apps/core/views.py
@@ -108,7 +108,7 @@ class ThemeViewMixin:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
             logger.error(
-                f"Could not select template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}"
+                f"Could not select template in [{templates}] for theme "
             )
             raise
 
@@ -120,7 +120,7 @@ class ThemeViewMixin:
             return select_template(self.add_theme_to_template_names(templates))
         except TemplateDoesNotExist:
             logger.error(
-                f"Could not find theme template in [{templates}] for theme path {self.request.site.siteconfiguration.theme_name}"
+                f"Could not find theme template in [{templates}]"
             )
             return ""
 

--- a/credentials/apps/credentials/templatetags/i18n_assets.py
+++ b/credentials/apps/credentials/templatetags/i18n_assets.py
@@ -2,7 +2,6 @@
 Template tags and helper functions for creating language tagged files
 """
 import logging
-
 from os.path import splitext
 
 from django import template
@@ -14,6 +13,7 @@ from django.utils.translation import get_language
 
 register = template.Library()
 logger = logging.getLogger(__name__)
+
 
 @register.filter(name="translate_file_path")
 def translate_file_path(filepath):
@@ -29,7 +29,7 @@ def translate_file_path(filepath):
     try:
         return select_template(paths).origin.template_name
     except TemplateDoesNotExist:
-        logger.error(f"Could not find translation template in [{paths}]" )
+        logger.error(f"Could not find translation template in [{paths}]")
         raise
 
 


### PR DESCRIPTION
When a template can't be found, there are no logs indicating the actual resource that was being accessed.
Added error logging for missing templates.