### PR TITLE
fix: added Makefile target to run tests with Karma

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+**Run JavaScript tests locally with Karma**
+
+There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.
+
+- [ ] Make sure you are inside the devstack container
+- [ ] Run `make test-karma`
+- [ ] All tests pass

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,11 @@ tests: ## Run tests and generate coverage report
 js-tests: ## Run javascript tests
 	npm run test-react
 
+test-karma: ## Run JS tests through Karma & install firefox. This command needs to be ran manually in the devstack container before submitting a pull request. It can not be run in CI as of APER-2136.
+	sudo apt-get update
+	sudo apt-get install --no-install-recommends -y firefox xvfb
+	xvfb-run $(NODE_BIN)/karma start
+
 # Requires locally installed software (firefox / xvfb). Easiest to run using `acceptance_tests_suite` command at the bottom
 accept: ## Run acceptance tests
 	./acceptance_tests/runtests.sh


### PR DESCRIPTION
This adds a new Makefile target that will install Firefox and run the tests using Karma. There is also a PR template that will remind future contributors to run these tests locally. Once a fix is found for getting these tests to run in CI, we will need to remove this PR template.