### PR TITLE
fix: program records are absent for nutmeg

### DIFF
--- a/credentials/templates/programs.html
+++ b/credentials/templates/programs.html
@@ -36,7 +36,7 @@
             isPublic: {{ is_public|yesno:"true,false"}},
             uuid: '{{uuid}}',
             helpUrl: '{{records_help_url}}',
-            programListUrl: '{{program_list_url}},
+            programListUrl: '{{program_list_url}}',
           });
         </script>
     {% endblock %}


### PR DESCRIPTION
**Description:**
This PR is necessary in order to fix the bug when going to page /records/programs/#UUIDprogram (). Added a quote to the JS script for correct display of the Program Record page.

Program records page crashes because of the error in the [JS script](https://github.com/openedx/credentials/blob/open-release/nutmeg.master/credentials/templates/programs.html#L39) syntax - missing the closing ' symbol. 
**Note:** the issue is also has been already fixed in [master](https://github.com/openedx/credentials/blob/master/credentials/templates/programs.html#L40)

[@DmytroAlipov](https://github.com/DmytroAlipov) is covered by the RaccoonGang CLA