### PR TITLE
fix: install npm and run webpack inside Dockerfile (PSRE-2079)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,6 +83,8 @@ RUN pip install -r requirements/production.txt
 
 RUN mkdir -p /edx/var/log
 
+# This line is after the python requirements so that changes to the code will not
+# bust the image cache
 COPY . /edx/app/credentials/credentials
 
 # Install dependencies in node_modules directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,16 +83,21 @@ RUN pip install -r requirements/production.txt
 
 RUN mkdir -p /edx/var/log
 
+COPY . /edx/app/credentials/credentials
+
+# Install dependencies in node_modules directory
+RUN npm install --no-save
+ENV NODE_BIN=/edx/app/credentials/credentials/node_modules
+ENV PATH="$NODE_BIN/.bin:$PATH"
+# Run webpack
+RUN webpack --config webpack.config.js
+
 # Code is owned by root so it cannot be modified by the application user.
 # So we copy it before changing users.
 USER app
 
 # Gunicorn 19 does not log to stdout or stderr by default. Once we are past gunicorn 19, the logging to STDOUT need not be specified.
 CMD gunicorn --workers=2 --name credentials -c /edx/app/credentials/credentials/credentials/docker_gunicorn_configuration.py --log-file - --max-requests=1000 credentials.wsgi:application
-
-# This line is after the requirements so that changes to the code will not
-# bust the image cache
-COPY . /edx/app/credentials/credentials
 
 # We don't switch back to the app user for devstack because we need devstack users to be
 # able to update requirements and generally run things as root.

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,9 @@ ENV PATH="$NODE_BIN/.bin:$PATH"
 # Run webpack
 RUN webpack --config webpack.config.js
 
+# Change static folder owner to application user.
+RUN chown -R app:app /edx/app/credentials/credentials/credentials/static
+
 # Code is owned by root so it cannot be modified by the application user.
 # So we copy it before changing users.
 USER app

--- a/credentials/settings/utils.py
+++ b/credentials/settings/utils.py
@@ -46,10 +46,7 @@ def get_logger_config(
         "- %(message)s"
     ).format(service_variant=service_variant, logging_env=logging_env, hostname=hostname)
 
-    if debug:
-        handlers = ["console"]
-    else:
-        handlers = ["local"]
+    handlers = ["console"]
 
     logger_config = {
         "version": 1,


### PR DESCRIPTION
Working on this ticket https://2u-internal.atlassian.net/browse/PSRE-2079 we are moving credentials app to k8s.
 First, we have enabled the stage credentials app on the stage EKS cluster and the app is throwing errors as `webpack-stats.json` is missing from the app directory, so adding instructions in Dockerfile to install npm dependencies and run webpack during the docker build. 
<img width="1093" alt="image" src="https://user-images.githubusercontent.com/7645388/209334620-4ec826fc-59c9-4185-94ec-391bff21cd55.png">
