### PR TITLE
fix: Allow Credentials to handle all redirects to the Learner Record MFE where appropriate

### DIFF
--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -179,12 +179,15 @@ class ProgramRecordView(ConditionallyRequireLoginMixin, RecordsEnabledMixin, Tem
     # NOTE: We _must_ keep this to ensure we are redirecting users to the Learner Record MFE when viewing shared public
     # program records.
     def get(self, request, *args, **kwargs):
-        # If we're using the Learner Record MFE for displaying program records AND this is a public program record
-        # request, redirect the request to the Learner Record MFE.
-        is_public = kwargs["is_public"]
-        if settings.USE_LEARNER_RECORD_MFE and is_public:
+        # If the Learner Record MFE is enabled, ensure we are redirecting users to the correct route depending on the
+        # privacy level of the program record entity.
+        if settings.USE_LEARNER_RECORD_MFE:
+            is_public = kwargs["is_public"]
             uuid = kwargs["uuid"]
-            url = urllib.parse.urljoin(settings.LEARNER_RECORD_MFE_RECORDS_PAGE_URL, f"shared/{uuid}")
+            if is_public:
+                url = urllib.parse.urljoin(settings.LEARNER_RECORD_MFE_RECORDS_PAGE_URL, f"shared/{uuid}")
+            else:
+                url = urllib.parse.urljoin(settings.LEARNER_RECORD_MFE_RECORDS_PAGE_URL, f"{uuid}")
             return HttpResponseRedirect(url)
 
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
[APER-2224]

Credentials already handles redirects for requests to the records page (credentials.blah.whatever/records) and shared program records (credentials.blah.whatever/programs/shared/{shared_program_record_UUID}/. Early in the implementation of the Learner Record MFE, we put logic in the LMS to build a URI directly to the _private_ program record pages in the LR MFE. This has proven to be a bad decision because it skips the cross-service authentication for the user.

This PR makes it so Credentials will handle _all_ redirects to the Learner Record MFE when appropriate. This solves an issue learners are experiencing when they are trying to make an authenticated REST API request before they have been authenticated with the Credentials service (APER-2224).

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
