### PR TITLE
fix: add console logging when user shares a program record via pathway

### DIFF
--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -12,7 +12,7 @@ from credentials.apps.credentials.api import (
     get_user_credentials_by_id,
 )
 from credentials.apps.credentials.data import UserCredentialStatus
-from credentials.apps.records.models import ProgramCertificate, ProgramCertRecord, UserCreditPathway, UserGrade
+from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway, UserGrade
 
 
 COURSE_CERTIFICATE_CONTENT_TYPE = ContentType.objects.filter(app_label="credentials", model="coursecertificate")

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -12,7 +12,7 @@ from credentials.apps.credentials.api import (
     get_user_credentials_by_id,
 )
 from credentials.apps.credentials.data import UserCredentialStatus
-from credentials.apps.records.models import ProgramCertRecord, UserCreditPathway, UserGrade
+from credentials.apps.records.models import ProgramCertificate, ProgramCertRecord, UserCreditPathway, UserGrade
 
 
 COURSE_CERTIFICATE_CONTENT_TYPE = ContentType.objects.filter(app_label="credentials", model="coursecertificate")

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from analytics.client import Client as SegmentClient
 from django import http
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import AccessMixin, LoginRequiredMixin
 from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404
@@ -19,7 +20,6 @@ from edx_ace import Recipient, ace
 from ratelimit.decorators import ratelimit
 
 from credentials.apps.catalog.models import Pathway, Program
-from credentials.apps.core.models import User
 from credentials.apps.core.views import ThemeViewMixin
 from credentials.apps.credentials.models import ProgramCertificate, UserCredential
 from credentials.apps.records.api import get_program_details, get_program_record_data
@@ -33,6 +33,7 @@ from .constants import RECORDS_RATE_LIMIT
 
 
 log = logging.getLogger(__name__)
+User = get_user_model()
 
 
 def rate_limited(request, exception):  # pylint: disable=unused-argument
@@ -90,15 +91,6 @@ class RecordsListBaseView(LoginRequiredMixin, RecordsEnabledMixin, TemplateView,
 
 
 class RecordsView(RecordsListBaseView):
-    # TODO: We should be able to remove this function as part of https://github.com/openedx/credentials/issues/1722
-    def _get_programs(self):
-        return get_user_program_data(
-            self.request.user.username,
-            self.request.site,
-            include_empty_programs=False,
-            include_retired_programs=True,
-        )
-
     # NOTE: We _should_ keep this for redirecting users to the Learner Record MFE to continue to work correctly
     def get(self, request, *args, **kwargs):
         # If the Learner Record MFE is enabled, redirect our user to the MFE, otherwise we use the legacy frontend
@@ -106,27 +98,6 @@ class RecordsView(RecordsListBaseView):
             return HttpResponseRedirect(settings.LEARNER_RECORD_MFE_RECORDS_PAGE_URL)
 
         return super().get(request, *args, **kwargs)
-
-    # TODO: We should be able to remove this function as part of https://github.com/openedx/credentials/issues/1722
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-
-        site_configuration = self.request.site.siteconfiguration
-        if site_configuration:
-            context["profile_url"] = urllib.parse.urljoin(
-                site_configuration.lms_url_root, "u/" + self.request.user.username
-            )
-            context["records_help_url"] = site_configuration.records_help_url
-
-        context["child_templates"]["masquerade"] = self.select_theme_template(["_masquerade.html"])
-
-        # Translators: A 'record' here means something like a transcript -- a list of courses and grades.
-        context["title"] = _("My Learner Records")
-        context["program_help"] = _(
-            "A program record is created once you have earned at least one course certificate in a program."
-        )
-
-        return context
 
 
 class ProgramListingView(RecordsListBaseView):
@@ -163,19 +134,6 @@ class ProgramListingView(RecordsListBaseView):
 class ProgramRecordView(ConditionallyRequireLoginMixin, RecordsEnabledMixin, TemplateView, ThemeViewMixin):
     template_name = "programs.html"
 
-    # TODO: We should be able to remove this function as part of https://github.com/openedx/credentials/issues/1722
-    def _get_record(self, uuid, is_public):
-        try:
-            data = get_program_details(self.request.user, self.request.site, uuid, is_public)
-        except ProgramCertRecord.DoesNotExist:
-            raise http.Http404()
-
-        # Only allow superusers to view a record with no data in it (i.e. don't allow learners to guess URLs and view)
-        if not self.request.user.is_superuser and data["record"]["program"]["empty"]:
-            raise http.Http404()
-
-        return data["record"]
-
     # NOTE: We _must_ keep this to ensure we are redirecting users to the Learner Record MFE when viewing shared public
     # program records.
     def get(self, request, *args, **kwargs):
@@ -191,42 +149,6 @@ class ProgramRecordView(ConditionallyRequireLoginMixin, RecordsEnabledMixin, Tem
             return HttpResponseRedirect(url)
 
         return super().get(request, *args, **kwargs)
-
-    # TODO: We should be able to remove this function as part of https://github.com/openedx/credentials/issues/1722
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        uuid = kwargs["uuid"]
-        is_public = kwargs["is_public"]
-        record = self._get_record(uuid, is_public)
-
-        site_configuration = self.request.site.siteconfiguration
-        records_help_url = site_configuration.records_help_url if site_configuration else ""
-        base_template = self.try_select_theme_template(["_base_style.html"])
-
-        program_list_url = "/records/"
-        if settings.USE_LEARNER_RECORD_MFE:
-            program_list_url = settings.LEARNER_RECORD_MFE_RECORDS_PAGE_URL
-
-        context.update(
-            {
-                "child_templates": {
-                    "footer": self.select_theme_template(["_footer.html"]),
-                    "header": self.select_theme_template(["_header.html"]),
-                    "masquerade": self.select_theme_template(["_masquerade.html"]),
-                },
-                "record": json.dumps(record, sort_keys=True),
-                "program_name": record.get("program", {}).get("name"),
-                "render_language": self.request.LANGUAGE_CODE,
-                "is_public": is_public,
-                "icons_template": self.try_select_theme_template(["credentials/programs.html"]),
-                "uuid": uuid,
-                "records_help_url": records_help_url,
-                "request": self.request,
-                "base_style_template": base_template,
-                "program_list_url": program_list_url,
-            }
-        )
-        return context
 
 
 @method_decorator(ratelimit(key="user", rate=RECORDS_RATE_LIMIT, method="POST", block=True), name="dispatch")
@@ -245,6 +167,7 @@ class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
 
         # verify that the user or an admin is making the request
         if username != request.user.get_username() and not request.user.is_staff:
+            log.info(f'[Share Program Record] Request made from user {request.user.get_username()} for username {username}')
             return JsonResponse({"error": "Permission denied"}, status=403)
 
         credential = UserCredential.objects.filter(
@@ -279,6 +202,9 @@ class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
                 "csv_link": csv_link,
             },
         )
+        log.info(f'[Share Program Record] User information sent is either full_name or username {request.user.get_full_name() or request.user.username}')
+        log.info(f'[Share Program Record] Program Record is {program.title} with UUID {program_uuid}')
+        log.info(f'[Share Program Record] Pathway is {pathway.name}')
         ace.send(msg)
 
         # Create a record of this email

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -229,6 +229,7 @@ class ProgramRecordView(ConditionallyRequireLoginMixin, RecordsEnabledMixin, Tem
         )
         return context
 
+
 @method_decorator(ratelimit(key="user", rate=RECORDS_RATE_LIMIT, method="POST", block=True), name="dispatch")
 class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
     """
@@ -245,7 +246,6 @@ class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
 
         # verify that the user or an admin is making the request
         if username != request.user.get_username() and not request.user.is_staff:
-            log.info(f'[Share Program Record] Request made from user {request.user.get_username()} for username {username}')
             return JsonResponse({"error": "Permission denied"}, status=403)
 
         credential = UserCredential.objects.filter(
@@ -281,7 +281,10 @@ class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
             },
         )
 
-        log.info(f'[Share Program Record] Internal Credentials user id [{user.id}] is enrolled in program [{program.title}] with UUID [{program_uuid}]. Pathway is [{pathway.name}]')
+        log.info(
+            f"[Share Program Record] Internal Credentials User [{user.id}] is sharing their progress in program "
+            f"[{program_uuid}] with pathway [{pathway_id}]"
+        )
         ace.send(msg)
 
         # Create a record of this email

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -263,7 +263,8 @@ class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
         preexisting_program_cert_record = ProgramCertRecord.objects.filter(user=user, program=program).exists()
         public_record, _ = ProgramCertRecord.objects.get_or_create(user=user, program=program)
 
-        record_path = reverse("records:public_programs", kwargs={"uuid": public_record.uuid.hex})        record_link = request.build_absolute_uri(record_path)
+        record_path = reverse("records:public_programs", kwargs={"uuid": public_record.uuid.hex})
+        record_link = request.build_absolute_uri(record_path)
         csv_link = urllib.parse.urljoin(record_link, "csv")
 
         msg = ProgramCreditRequest(request.site, user.email).personalize(
@@ -279,7 +280,8 @@ class ProgramSendView(LoginRequiredMixin, RecordsEnabledMixin, View):
                 "csv_link": csv_link,
             },
         )
-        log.info(f'[Share Program Record] User {request.user.get_full_name()} is enrolled in Program {program.title} with UUID {program_uuid}. Pathway is {pathway.name}')
+
+        log.info(f'[Share Program Record] Internal Credentials user id [{user.id}] is enrolled in program [{program.title}] with UUID [{program_uuid}]. Pathway is [{pathway.name}]')
         ace.send(msg)
 
         # Create a record of this email


### PR DESCRIPTION
[Jira Ticket: APER-2217](https://2u-internal.atlassian.net/browse/APER-2217)
* when users send their program via email, we will now log the internal credential user id, program name + uuid, and the pathway in order to make our bug investigation easier. 
* use get_user_model to safely retrieve User data

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
