### PR TITLE
temp: omit publicPath from webpack.config.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,8 +31,7 @@ module.exports = {
   output: {
     path: path.resolve('./credentials/static/bundles/'),
     filename: '[name]-[contenthash].js',
-    libraryTarget: 'window',
-    publicPath: '/static/bundles/'
+    libraryTarget: 'window'
   },
   plugins: getPlugins(),
   externals: {


### PR DESCRIPTION
Temporary change that is a test fix for APER-2210. I read that if `publicPath` is set in a webpack config then `django-webpack-loader` will use `publicPath` over the static URL settings. I think this could be the source of the problem with some of our assets being accessed at an incorrect URL.

I'm making this change based on a conversation here: https://github.com/django-webpack/django-webpack-loader/issues/107, specifically:
```
@mik3y Preferring publicPath over django's storage is a feature and the only way to give preference to django's storage right now is to omit publicPath from your webpack config like you correctly pointed out.
```