### PR TITLE
chore: update requirements to install the `edx-event-bus-kafka` package

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -13,7 +13,7 @@ asgiref==3.6.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django
-astroid==2.15.0
+astroid==2.15.1
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -24,6 +24,7 @@ attrs==22.2.0
     #   -r requirements/production.txt
     #   edx-ace
     #   jsonschema
+    #   openedx-events
     #   pytest
 backoff==1.10.0
     # via
@@ -42,11 +43,11 @@ bleach==6.0.0
     #   -r requirements/production.txt
 bok-choy==1.1.1
     # via -r requirements/dev.txt
-boto3==1.26.90
+boto3==1.26.100
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.29.90
+botocore==1.29.100
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -99,9 +100,9 @@ coreschema==0.0.4
     #   -r requirements/production.txt
     #   coreapi
     #   drf-yasg
-coverage==7.2.1
+coverage==7.2.2
     # via -r requirements/dev.txt
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -154,8 +155,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -178,7 +181,7 @@ django-extensions==3.2.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-django-filter==22.1
+django-filter==23.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -277,14 +280,19 @@ edx-django-sites-extensions==4.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+edx-event-bus-kafka==3.9.6
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -295,11 +303,12 @@ edx-i18n-tools==0.9.2
     #   edx-credentials-themes
 edx-lint==5.3.4
     # via -r requirements/dev.txt
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via
     #   -r requirements/dev.txt
@@ -308,17 +317,23 @@ edx-toggles==5.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.1.1
     # via
     #   -r requirements/dev.txt
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/dev.txt
-faker==17.6.0
+faker==18.3.1
     # via
     #   -r requirements/dev.txt
     #   factory-boy
-filelock==3.9.0
+fastavro==1.7.3
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   openedx-events
+filelock==3.10.7
     # via
     #   -r requirements/dev.txt
     #   tox
@@ -343,7 +358,7 @@ idna==3.4
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -389,7 +404,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/dev.txt
     #   astroid
-markdown==3.4.1
+markdown==3.4.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -415,7 +430,7 @@ mysqlclient==2.1.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -433,6 +448,11 @@ openapi-codec==1.3.2
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/dev.txt
@@ -451,7 +471,7 @@ path==16.6.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-i18n-tools
-pathspec==0.11.0
+pathspec==0.11.1
     # via
     #   -r requirements/dev.txt
     #   black
@@ -464,7 +484,7 @@ pillow==9.4.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/dev.txt
     #   black
@@ -517,7 +537,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.0
+pylint==2.17.1
     # via
     #   -r requirements/dev.txt
     #   edx-lint
@@ -585,7 +605,7 @@ python3-openid==3.2.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -656,7 +676,7 @@ semantic-version==2.10.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
-simplejson==3.18.3
+simplejson==3.18.4
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -686,12 +706,12 @@ slumber==0.7.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -729,7 +749,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -737,7 +757,7 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/dev.txt
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.9
     # via
     #   -r requirements/dev.txt
     #   responses
@@ -793,7 +813,7 @@ zope-event==4.6
     # via
     #   -r requirements/production.txt
     #   gevent
-zope-interface==5.5.2
+zope-interface==6.0
     # via
     #   -r requirements/production.txt
     #   gevent

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,6 +33,8 @@ edx-django-release-util
 edx-django-sites-extensions
 edx-django-utils
 edx-drf-extensions
+# edx-event-bus-kafka 3.7.0 introduces `reset_offsets_and_sleep_indefinitely`
+edx-event-bus-kafka>=3.7.1
 edx-opaque-keys
 edx-rest-api-client
 edx-toggles

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,12 +4,14 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/base.in
 asgiref==3.6.0
     # via django
 attrs==22.2.0
-    # via edx-ace
+    # via
+    #   edx-ace
+    #   openedx-events
 backoff==1.10.0
     # via analytics-python
 bleach==6.0.0
@@ -38,7 +40,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   pyjwt
     #   social-auth-core
@@ -69,8 +71,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via django-statici18n
@@ -82,7 +86,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-extensions==3.2.1
     # via -r requirements/base.in
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/base.in
 django-hijack==2.3.0
     # via
@@ -133,29 +137,37 @@ edx-django-release-util==1.2.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.in
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
     # via -r requirements/base.in
+edx-event-bus-kafka==3.9.6
+    # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via edx-credentials-themes
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/base.in
 edx-toggles==5.0.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   edx-event-bus-kafka
+fastavro==1.7.3
+    # via openedx-events
 future==0.18.3
     # via pyjwkest
 idna==3.4
     # via requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via markdown
 inflection==0.5.1
     # via drf-yasg
@@ -165,7 +177,7 @@ jinja2==3.1.2
     # via
     #   code-annotations
     #   coreschema
-markdown==3.4.1
+markdown==3.4.3
     # via -r requirements/base.in
 markupsafe==2.1.2
     # via jinja2
@@ -173,7 +185,7 @@ monotonic==1.6
     # via analytics-python
 mysqlclient==2.1.1
     # via -r requirements/base.in
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -183,6 +195,8 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
+openedx-events==7.0.0
+    # via edx-event-bus-kafka
 packaging==23.0
     # via drf-yasg
 path==16.6.0
@@ -225,7 +239,7 @@ python-slugify==8.0.1
     # via code-annotations
 python3-openid==3.2.0
     # via social-auth-core
-pytz==2022.7.1
+pytz==2023.2
     # via
     #   -r requirements/base.in
     #   django
@@ -259,7 +273,7 @@ sailthru-client==2.2.3
     # via edx-ace
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.18.3
+simplejson==3.18.4
     # via
     #   django-rest-swagger
     #   sailthru-client
@@ -276,11 +290,11 @@ six==1.16.0
     #   python-memcached
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/test.txt
 asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.0
+astroid==2.15.1
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -20,6 +20,7 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   edx-ace
     #   jsonschema
+    #   openedx-events
     #   pytest
 backoff==1.10.0
     # via
@@ -74,9 +75,9 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage==7.2.1
+coverage==7.2.2
     # via -r requirements/test.txt
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/test.txt
     #   paramiko
@@ -123,8 +124,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -141,7 +144,7 @@ django-debug-toolbar==3.8.1
     # via -r requirements/dev.in
 django-extensions==3.2.1
     # via -r requirements/test.txt
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/test.txt
 django-hijack==2.3.0
     # via
@@ -202,13 +205,16 @@ edx-django-release-util==1.2.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==4.0.0
     # via -r requirements/test.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via -r requirements/test.txt
+edx-event-bus-kafka==3.9.6
     # via -r requirements/test.txt
 edx-i18n-tools==0.9.2
     # via
@@ -217,25 +223,32 @@ edx-i18n-tools==0.9.2
     #   edx-credentials-themes
 edx-lint==5.3.4
     # via -r requirements/test.txt
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
 edx-toggles==5.0.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==17.6.0
+faker==18.3.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.9.0
+fastavro==1.7.3
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
+filelock==3.10.7
     # via
     #   -r requirements/test.txt
     #   tox
@@ -250,7 +263,7 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/test.txt
     #   markdown
@@ -285,7 +298,7 @@ lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
-markdown==3.4.1
+markdown==3.4.3
     # via -r requirements/test.txt
 markupsafe==2.1.2
     # via
@@ -305,7 +318,7 @@ mypy-extensions==1.0.0
     #   black
 mysqlclient==2.1.1
     # via -r requirements/test.txt
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -318,6 +331,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/test.txt
@@ -332,7 +349,7 @@ path==16.6.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
-pathspec==0.11.0
+pathspec==0.11.1
     # via
     #   -r requirements/test.txt
     #   black
@@ -342,7 +359,7 @@ pbr==5.11.1
     #   stevedore
 pillow==9.4.0
     # via -r requirements/test.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   -r requirements/test.txt
     #   black
@@ -387,7 +404,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.0
+pylint==2.17.1
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -443,7 +460,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.2
     # via
     #   -r requirements/test.txt
     #   django
@@ -501,7 +518,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.18.3
+simplejson==3.18.4
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -528,11 +545,11 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -564,7 +581,7 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -572,7 +589,7 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.9
     # via
     #   -r requirements/test.txt
     #   responses

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -20,7 +20,7 @@ idna==3.4
     # via requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
@@ -34,7 +34,7 @@ pygments==2.14.0
     # via
     #   jsx-lexer
     #   sphinx
-pytz==2022.7.1
+pytz==2023.2
     # via babel
 requests==2.28.2
     # via sphinx

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-wheel==0.38.4
+wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -16,7 +16,7 @@ pyproject-hooks==1.0.0
     # via build
 tomli==2.0.1
     # via build
-wheel==0.38.4
+wheel==0.40.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/base.txt
 asgiref==3.6.0
     # via
@@ -14,15 +14,16 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
+    #   openedx-events
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
 bleach==6.0.0
     # via -r requirements/base.txt
-boto3==1.26.90
+boto3==1.26.100
     # via django-ses
-botocore==1.29.90
+botocore==1.29.100
     # via
     #   boto3
     #   s3transfer
@@ -59,7 +60,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -93,8 +94,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -109,7 +112,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-extensions==3.2.1
     # via -r requirements/base.txt
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/base.txt
 django-hijack==2.3.0
     # via
@@ -164,26 +167,36 @@ edx-django-release-util==1.2.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via -r requirements/base.txt
+edx-event-bus-kafka==3.9.6
     # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/base.txt
     #   edx-credentials-themes
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
 edx-toggles==5.0.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
+fastavro==1.7.3
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 future==0.18.3
     # via
     #   -r requirements/base.txt
@@ -198,7 +211,7 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/base.txt
     #   markdown
@@ -219,7 +232,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markdown==3.4.1
+markdown==3.4.3
     # via -r requirements/base.txt
 markupsafe==2.1.2
     # via
@@ -231,7 +244,7 @@ monotonic==1.6
     #   analytics-python
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
@@ -247,6 +260,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/base.txt
@@ -316,7 +333,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -365,7 +382,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.18.3
+simplejson==3.18.4
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -386,11 +403,11 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -432,7 +449,7 @@ zipp==3.15.0
     #   importlib-metadata
 zope-event==4.6
     # via gevent
-zope-interface==5.5.2
+zope-interface==6.0
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
+analytics-python==1.4.post1
     # via -r requirements/base.txt
 asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.0
+astroid==2.15.1
     # via
     #   pylint
     #   pylint-celery
@@ -18,6 +18,7 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
+    #   openedx-events
     #   pytest
 backoff==1.10.0
     # via
@@ -69,9 +70,9 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage==7.2.1
+coverage==7.2.2
     # via -r requirements/test.in
-cryptography==39.0.2
+cryptography==40.0.1
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -109,8 +110,10 @@ distlib==0.3.6
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -125,7 +128,7 @@ django-crum==0.7.9
     #   edx-toggles
 django-extensions==3.2.1
     # via -r requirements/base.txt
-django-filter==22.1
+django-filter==23.1
     # via -r requirements/base.txt
 django-hijack==2.3.0
     # via
@@ -178,13 +181,16 @@ edx-django-release-util==1.2.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.0.0
     # via -r requirements/base.txt
-edx-django-utils==5.2.0
+edx-django-utils==5.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via -r requirements/base.txt
+edx-event-bus-kafka==3.9.6
     # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -192,21 +198,28 @@ edx-i18n-tools==0.9.2
     #   edx-credentials-themes
 edx-lint==5.3.4
     # via -r requirements/test.in
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
 edx-toggles==5.0.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==17.6.0
+faker==18.3.1
     # via factory-boy
-filelock==3.9.0
+fastavro==1.7.3
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
+filelock==3.10.7
     # via
     #   tox
     #   virtualenv
@@ -220,7 +233,7 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==6.0.0
+importlib-metadata==6.1.0
     # via
     #   -r requirements/base.txt
     #   markdown
@@ -247,7 +260,7 @@ lazy==1.5
     # via bok-choy
 lazy-object-proxy==1.9.0
     # via astroid
-markdown==3.4.1
+markdown==3.4.3
     # via -r requirements/base.txt
 markupsafe==2.1.2
     # via
@@ -263,7 +276,7 @@ mypy-extensions==1.0.0
     # via black
 mysqlclient==2.1.1
     # via -r requirements/base.txt
-newrelic==8.7.0
+newrelic==8.7.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -276,6 +289,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/base.txt
@@ -287,7 +304,7 @@ path==16.6.0
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
-pathspec==0.11.0
+pathspec==0.11.1
     # via black
 pbr==5.11.1
     # via
@@ -295,7 +312,7 @@ pbr==5.11.1
     #   stevedore
 pillow==9.4.0
     # via -r requirements/base.txt
-platformdirs==3.1.1
+platformdirs==3.2.0
     # via
     #   black
     #   pylint
@@ -336,7 +353,7 @@ pyjwt[crypto]==2.6.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.17.0
+pylint==2.17.1
     # via
     #   edx-lint
     #   pylint-celery
@@ -381,7 +398,7 @@ python3-openid==3.2.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-pytz==2022.7.1
+pytz==2023.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -432,7 +449,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.18.3
+simplejson==3.18.4
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -456,11 +473,11 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.0.0
+social-auth-app-django==5.1.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.3.0
+social-auth-core==4.4.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -488,13 +505,13 @@ tomli==2.0.1
     #   pylint
     #   pytest
     #   tox
-tomlkit==0.11.6
+tomlkit==0.11.7
     # via pylint
 tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.in
-types-pyyaml==6.0.12.8
+types-pyyaml==6.0.12.9
     # via responses
 typing-extensions==4.5.0
     # via

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -17,7 +17,7 @@ path==16.6.0
     # via edx-i18n-tools
 polib==1.2.0
     # via edx-i18n-tools
-pytz==2022.7.1
+pytz==2023.2
     # via django
 pyyaml==5.4.1
     # via


### PR DESCRIPTION
This PR updates our `base.in` requirement file to include the `edx-event-bus-kafka` package. This will be required to prepare the Credentials IDA for event bus functionality in the future.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
