### PR TITLE
chore: Add event bus requirements to Credentials

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -25,6 +25,7 @@ attrs==22.2.0
     #   -r requirements/production.txt
     #   edx-ace
     #   jsonschema
+    #   openedx-events
     #   pytest
 backoff==1.10.0
     # via
@@ -155,8 +156,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -283,9 +286,14 @@ edx-django-utils==5.3.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+edx-event-bus-kafka==3.9.6
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -296,11 +304,12 @@ edx-i18n-tools==0.9.2
     #   edx-credentials-themes
 edx-lint==5.3.4
     # via -r requirements/dev.txt
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via
     #   -r requirements/dev.txt
@@ -309,6 +318,7 @@ edx-toggles==5.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.1.1
     # via
     #   -r requirements/dev.txt
@@ -319,6 +329,11 @@ faker==18.3.1
     # via
     #   -r requirements/dev.txt
     #   factory-boy
+fastavro==1.7.3
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   openedx-events
 filelock==3.10.7
     # via
     #   -r requirements/dev.txt
@@ -434,6 +449,11 @@ openapi-codec==1.3.2
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/dev.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -33,6 +33,7 @@ edx-django-release-util
 edx-django-sites-extensions
 edx-django-utils
 edx-drf-extensions
+edx-event-bus-kafka
 edx-opaque-keys
 edx-rest-api-client
 edx-toggles

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,9 @@ analytics-python==1.4.0
 asgiref==3.6.0
     # via django
 attrs==22.2.0
-    # via edx-ace
+    # via
+    #   edx-ace
+    #   openedx-events
 backoff==1.10.0
     # via analytics-python
 bleach==6.0.0
@@ -71,8 +73,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via django-statici18n
@@ -139,20 +143,28 @@ edx-django-utils==5.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
     # via -r requirements/base.in
+edx-event-bus-kafka==3.9.6
+    # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via edx-credentials-themes
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/base.in
 edx-toggles==5.0.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   edx-event-bus-kafka
+fastavro==1.7.3
+    # via openedx-events
 future==0.18.3
     # via pyjwkest
 idna==3.4
@@ -185,6 +197,8 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
+openedx-events==7.0.0
+    # via edx-event-bus-kafka
 packaging==23.0
     # via drf-yasg
 path==16.6.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,6 +22,7 @@ attrs==22.2.0
     #   -r requirements/test.txt
     #   edx-ace
     #   jsonschema
+    #   openedx-events
     #   pytest
 backoff==1.10.0
     # via
@@ -125,8 +126,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -208,9 +211,12 @@ edx-django-utils==5.3.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via -r requirements/test.txt
+edx-event-bus-kafka==3.9.6
     # via -r requirements/test.txt
 edx-i18n-tools==0.9.2
     # via
@@ -219,14 +225,17 @@ edx-i18n-tools==0.9.2
     #   edx-credentials-themes
 edx-lint==5.3.4
     # via -r requirements/test.txt
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/test.txt
 edx-toggles==5.0.0
-    # via -r requirements/test.txt
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.1.1
     # via
     #   -r requirements/test.txt
@@ -237,6 +246,10 @@ faker==18.3.1
     # via
     #   -r requirements/test.txt
     #   factory-boy
+fastavro==1.7.3
+    # via
+    #   -r requirements/test.txt
+    #   openedx-events
 filelock==3.10.7
     # via
     #   -r requirements/test.txt
@@ -320,6 +333,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/test.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,6 +16,7 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
+    #   openedx-events
 backoff==1.10.0
     # via
     #   -r requirements/base.txt
@@ -95,8 +96,10 @@ django==3.2.18
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -170,22 +173,32 @@ edx-django-utils==5.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via -r requirements/base.txt
+edx-event-bus-kafka==3.9.6
     # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/base.txt
     #   edx-credentials-themes
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
 edx-toggles==5.0.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
+fastavro==1.7.3
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 future==0.18.3
     # via
     #   -r requirements/base.txt
@@ -249,6 +262,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,6 +20,7 @@ attrs==22.2.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
+    #   openedx-events
     #   pytest
 backoff==1.10.0
     # via
@@ -111,8 +112,10 @@ distlib==0.3.6
     #   edx-django-sites-extensions
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-i18n-tools
     #   edx-toggles
+    #   openedx-events
     #   xss-utils
 django-appconf==1.0.5
     # via
@@ -184,9 +187,12 @@ edx-django-utils==5.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
 edx-drf-extensions==8.4.1
+    # via -r requirements/base.txt
+edx-event-bus-kafka==3.9.6
     # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
@@ -194,20 +200,27 @@ edx-i18n-tools==0.9.2
     #   edx-credentials-themes
 edx-lint==5.3.4
     # via -r requirements/test.in
-edx-opaque-keys==2.3.0
+edx-opaque-keys[django]==2.3.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   openedx-events
 edx-rest-api-client==5.5.0
     # via -r requirements/base.txt
 edx-toggles==5.0.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
 faker==18.3.1
     # via factory-boy
+fastavro==1.7.3
+    # via
+    #   -r requirements/base.txt
+    #   openedx-events
 filelock==3.10.7
     # via
     #   tox
@@ -278,6 +291,10 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+openedx-events==7.0.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-event-bus-kafka
 packaging==23.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
This PR updates our base.in requirement file to include the edx-event-bus-kafka package. This will be required to prepare the Credentials IDA for event bus functionality in the future.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
