### PR TITLE
fix: Don't encode to bytes for CSV filename

### DIFF
--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -5,6 +5,7 @@ import csv
 import datetime
 import io
 import json
+import re
 import urllib.parse
 import uuid
 from unittest.mock import patch
@@ -1316,18 +1317,14 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
         """
         Verify that the filename in response Content-Disposition is utf-8 encoded
         """
-        filename = "{username}_{program_name}_grades".format(
-            username=self.user.username, program_name=self.program_cert_record.program.title
-        )
-        filename = filename.replace(" ", "_").lower().encode("utf-8")
-        expected = f'attachment; filename="{filename}.csv"'
+        re_expected = r'attachment; filename="test-user_test_program_[0-9a-z]+_grades\.csv"'
 
         response = self.client.get(
             reverse("records:program_record_csv", kwargs={"uuid": self.program_cert_record.uuid.hex})
         )
         actual = response["Content-Disposition"]
 
-        self.assertEqual(actual, expected)
+        self.assertTrue(re.fullmatch(re_expected, actual))
 
 
 @ddt.ddt

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -453,6 +453,6 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
             properties=properties,
             segment_client=segment_client,
         )
-        filename = filename.replace(" ", "_").lower().encode("utf-8")
+        filename = filename.replace(" ", "_").lower()
         response["Content-Disposition"] = 'attachment; filename="{filename}.csv"'.format(filename=filename)
         return response


### PR DESCRIPTION
This was producing filenames like `b'something'.csv` rather than just `something.csv`. The test didn't catch it because it just repeated the same code it was testing. There's randomness in the test data, so this uses a regex to get as close as possible to an equality assertion.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
