### PR TITLE
chore: add `edx_django_utils.user` to Django apps

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -61,6 +61,7 @@ THIRD_PARTY_APPS = [
     "drf_yasg",
     "hijack",
     "xss_utils",
+    "edx_django_utils.user"
 ]
 
 PROJECT_APPS = [


### PR DESCRIPTION
Add `edx_django_utils.user` to installed Django apps. This is required to support managing access to Credentials via "app permissions".

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
