### PR TITLE
build: use GHA for running code coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,10 @@ jobs:
           make static
           make tests
       - name: Run code coverage
-        run: |
-          make coverage
-          pip install codecov
-          codecov
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          fail_ci_if_error: true
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have to change our approach for collecting code coverage statistics after the (deprecated) codecov package was yanked from pypi.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
