### PR TITLE
feat: Consume `CERTIFICATE_CREATED` events using the event bus

### DIFF
--- a/credentials/apps/core/api.py
+++ b/credentials/apps/core/api.py
@@ -1,0 +1,46 @@
+"""
+Python APIs exposed by the core Django app.
+"""
+import logging
+
+from django.contrib.auth import get_user_model
+from openedx_events.learning.data import UserData
+
+
+User = get_user_model()
+logger = logging.getLogger(__name__)
+
+
+def get_or_create_user_from_event_data(user_data):
+    """
+    Utility function to retrieve a User instance while processing event bus events. If the user does not exist, we will
+    create a new User instance using data from the event the Credentials IDA is currently processing.
+
+    Args:
+        user_data (UserData): The learner's data extracted from the event bus event being processed
+
+    Returns:
+        user (User): The User instance associated with the learner from the event data
+        created (Bool): A boolean describing if the user existed (and was retrieved) or created
+    """
+    if not user_data or not isinstance(user_data, UserData):
+        logger.error("Received null or unexpected data type when attempting to retrieve User information")
+        return None, None
+
+    try:
+        # create the user if they don't exist, this follows similar behavior that our JWT authentication implements if
+        # a user doesn't exist when we're making network calls across services
+        user, created = User.objects.get_or_create(username=user_data.pii.username)
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception("Error occurred retrieving or creating a user")
+        return None, None
+
+    if created:
+        logger.info(f"Created new Credentials user with id {user.id}. Updating attributes from event data...")
+        user.lms_user_id = user_data.id
+        user.is_active = user_data.is_active
+        user.full_name = user_data.pii.name
+        user.email = user_data.pii.email
+        user.save()
+
+    return user, created

--- a/credentials/apps/core/tests/factories.py
+++ b/credentials/apps/core/tests/factories.py
@@ -20,6 +20,7 @@ class UserFactory(django.DjangoModelFactory):
     last_name = Faker("last_name")
     full_name = Faker("name")
     email = Faker("safe_email")
+    lms_user_id = Faker("random_int")
     is_staff = False
     is_superuser = False
     is_active = True

--- a/credentials/apps/core/tests/test_api.py
+++ b/credentials/apps/core/tests/test_api.py
@@ -1,0 +1,73 @@
+"""
+Tests for the Python functions in the Core app's `api.py` file
+"""
+import ddt
+from django.test import TestCase
+from openedx_events.learning.data import UserData, UserPersonalData
+from testfixtures import LogCapture
+
+from credentials.apps.core.api import get_or_create_user_from_event_data
+from credentials.apps.core.tests.factories import UserFactory
+
+
+@ddt.ddt
+class CoreApiTests(TestCase):
+    """
+    Unit tests for `api.py` functions in the Core Django app
+    """
+
+    def test_get_existing_user(self):
+        """
+        Test case to verify the behavior of the `get_or_create_user_from_event_bus_data` function when trying to
+        retrieve a user that already exists in the system. Verifies that the user returned is the one we expected.
+        """
+        user = UserFactory()
+        user_event_data = UserData(
+            pii=UserPersonalData(
+                username=user.username,
+                email=user.email,
+                name=user.full_name,
+            ),
+            id=user.lms_user_id,
+            is_active=user.is_active,
+        )
+
+        returned_user, created = get_or_create_user_from_event_data(user_event_data)
+        assert not created
+        assert returned_user.username == user.username
+        assert returned_user.email == user.email
+        assert returned_user.full_name == user.full_name
+        assert returned_user.lms_user_id == user.lms_user_id
+        assert returned_user.is_active == user.is_active
+
+    def test_create_new_user(self):
+        """
+        Test case to verify the behavior of the `get_or_create_user_from_event_bus_data` function when trying to
+        retrieve a user that doesn't exist in Credentials. Verifies the user creation process.
+        """
+        new_user_event_data = UserData(
+            pii=UserPersonalData(username="uginislame", email="coolperson@yup.com", name="Nicol Bolas"),
+            id=123456789,
+            is_active=True,
+        )
+
+        user, created = get_or_create_user_from_event_data(new_user_event_data)
+        assert created
+        assert user.username == "uginislame"
+        assert user.email == "coolperson@yup.com"
+        assert user.full_name == "Nicol Bolas"
+        assert user.lms_user_id == 123456789
+        assert user.is_active
+
+    @ddt.data(None, True)
+    def test_get_user_no_user_data(self, bad_data):
+        """
+        Test case to verify the behavior of the `get_or_create_user_from_event_bus_data` function when passed unexpected
+        data.
+        """
+        expected_message = "Received null or unexpected data type when attempting to retrieve User information"
+
+        with LogCapture() as log:
+            get_or_create_user_from_event_data(bad_data)
+
+        assert log.records[0].msg == expected_message

--- a/credentials/apps/credentials/api.py
+++ b/credentials/apps/credentials/api.py
@@ -1,10 +1,128 @@
-from credentials.apps.credentials.utils import filter_visible, get_credential_visible_date, get_credential_visible_dates
+"""
+Python API utility functions exposed by the `credentials` Django app.
+"""
+import logging
 
-from .models import (
+from django.contrib.contenttypes.models import ContentType
+
+from credentials.apps.catalog.api import get_course_runs_by_course_run_keys
+from credentials.apps.credentials.constants import UserCredentialStatus
+from credentials.apps.credentials.models import (
     CourseCertificate as _CourseCertificate,
     ProgramCertificate as _ProgramCertificate,
     UserCredential as _UserCredential,
 )
+from credentials.apps.credentials.utils import filter_visible, get_credential_visible_date, get_credential_visible_dates
+
+
+logger = logging.getLogger(__name__)
+
+
+def _get_course_run(course_run_key):
+    """
+    A utility function that wraps the `get_course_runs_by_course_run_keys` function from the Catalog Python API. If the
+    returned query set yields a result then we pass back that course run instance, otherwise we log a warning.
+
+    Arguments:
+        course_run_key (String): The course run key we are trying to retrieve
+
+    Returns:
+        course_run (CourseRun): The course run instance requested (or None)
+    """
+    course_run = None
+
+    logger.info(f"Attempting to retrieve course run with key [{course_run_key}]")
+    results = get_course_runs_by_course_run_keys([course_run_key])
+    # `get_course_runs_by_course_run_keys` returns a query set, ensure we have results and that there is just one match
+    if results and results.count() == 1:
+        course_run = results[0]
+    else:
+        logger.warning(f"Could not retrieve a course run with key [{course_run_key}]")
+
+    return course_run
+
+
+def _update_or_create_credential(username, credential_type, credential_id, status):
+    """
+    A utility function responsible for issuing (or updating) a UserCredential (certificate) to a learner.
+
+    Args:
+        username (String): The username of the user the credential should be issued to
+        credential_type (CourseCertificate OR ProgramCertificate): The credential type we are issuing
+        credential_id (Int): The id number of the (Program or Course) Certificate Configuration we are issuing
+        status (String): The status of the credential (e.g. "awarded" or "revoked")
+
+    Returns:
+        credentials (UserCredential): The issued or updated credential
+        created (Boolean): A boolean describing if the record was created or updated
+    """
+    try:
+        content_type = ContentType.objects.get_for_model(credential_type)
+        credential, created = _UserCredential.objects.update_or_create(
+            username=username, credential_content_type=content_type, credential_id=credential_id, status=status
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(
+            f"Error occurred processing a credential with credential_id [{credential_id}] for user [{username}]"
+        )
+        return None, None
+    else:
+        logger.info(
+            f"Processed credential for user [{username}] with status [{status}]. UUID: [{credential.uuid}], created: "
+            f"[{created}]"
+        )
+        return credential, created
+
+
+def get_course_cert_config(course_run, mode, create=False):
+    """
+    A utility function that attempts to retrieve a course certificate configuration from the provided course run
+    instance. Optionally attempts to create a course certificate configuration if one does not exist.
+
+    Arguments:
+        course_run (CourseRun): The CourseRun instance
+        mode (String): The "mode" of the course run provided (e.g. `verified`, `honor`, `masters`, etc.)
+        create (Boolean): A boolean that controls whether we should attempt to create a cert config if one doesn't exist
+
+    Returns:
+        course_cert_config (CourseCertificate): The retrieved (or created) CourseCertificate instance
+    """
+    course_cert_config = None
+    try:
+        logger.info(f"Attempting to retrieve the course certificate configuration for course run [{course_run.key}]")
+        course_cert_config = _CourseCertificate.objects.get(course_run=course_run)
+    except _CourseCertificate.DoesNotExist:
+        logger.error(f"A course certificate configuration could not be found for course run [{course_run.key}]")
+    finally:
+        if not course_cert_config and create:
+            course_cert_config = create_course_cert_config(course_run, course_run.course.site, mode)
+
+    return course_cert_config
+
+
+def create_course_cert_config(course_run, site, mode):
+    """
+    A utility function that attempts to create a CourseCertificate instance from the provided data.
+
+    Arguments:
+        course_run (CourseRun): The course run associated with the CourseCertificate instance to be created
+        site (Site): The site associated with the course run
+        mode (String): The "certificate type" of the CourseCertificate (e.g. verified, honor, etc.)
+
+    Returns:
+        course_cert_config (CourseCertificate): The CourseCertificate instance created
+    """
+    logger.info(f"Creating a course certificate configuration for course run [{course_run.key}]")
+
+    course_cert_config = None
+    try:
+        course_cert_config = _CourseCertificate.objects.create(
+            course_id=course_run.key, course_run=course_run, site=site, is_active=True, certificate_type=mode
+        )
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.exception(f"Error occurred creating a CourseCertificate configuration for course run [{course_run.key}]")
+
+    return course_cert_config
 
 
 def get_course_certificates_with_ids(course_credential_ids, request_site):
@@ -102,3 +220,36 @@ def get_credential_dates(user_credentials, many):
         return get_credential_visible_dates(user_credentials)
     else:
         return get_credential_visible_date(user_credentials, use_date_override=True)
+
+
+def award_course_certificate(user, course_run_key, mode):
+    """
+    A utility function that will attempt to issue a certificate to a user from an event consumed from the event bus.
+
+    Args:
+        user (User): The User instance retrieved from event details
+        course_run_key (String): The course run key that the learner earned a certificate in
+        mode (String): The "certificate type" of the certificate. Used if we need to create a new CourseCertificate
+    """
+    course_run = _get_course_run(course_run_key)
+    if course_run:
+        # Check if a (course) certificate configuration exists before we attempt to award the certificate. We cannot
+        # award a (course) credential if this configuration doesn't exist. If one doesn't exist, try to create one on
+        # the fly (this tracks with legacy behavior when awarding certs through the REST API pathway)
+        course_cert_config = get_course_cert_config(course_run, mode, create=True)
+        if course_cert_config:
+            _update_or_create_credential(
+                user.username, _CourseCertificate, course_cert_config.id, UserCredentialStatus.AWARDED
+            )
+        else:
+            logger.error(
+                f"Error awarding a course certificate to user [{user.id}] in course run [{course_run_key}]. A course "
+                "certificate configuration could not be found or created."
+            )
+            return
+    else:
+        logger.error(
+            f"Error awarding a course certificate to user [{user.id}] in course run [{course_run_key}]. Could not find "
+            f"a course run with key [{course_run_key}]"
+        )
+        return

--- a/credentials/apps/credentials/apps.py
+++ b/credentials/apps/credentials/apps.py
@@ -19,6 +19,9 @@ class CredentialsConfig(AppConfig):
     verbose_name = "Credentials"
 
     def ready(self):
+        # connect signal handlers for event bus functionality
+        from credentials.apps.credentials import signals  # pylint: disable=unused-import,import-outside-toplevel
+
         required_config_settings = ("CREDENTIALS_SERVICE_USER",)
 
         missing_config_settings = []

--- a/credentials/apps/credentials/management/commands/consume_events.py
+++ b/credentials/apps/credentials/management/commands/consume_events.py
@@ -1,0 +1,7 @@
+"""
+Import the `consume_events` management command from the `event-bus-kafka` package in order to expose it here.
+
+This copies the approach currently used by the Discovery IDA.
+"""
+# pylint: disable=unused-import
+from edx_event_bus_kafka.management.commands.consume_events import Command

--- a/credentials/apps/credentials/signals.py
+++ b/credentials/apps/credentials/signals.py
@@ -1,0 +1,46 @@
+"""
+Signal receivers for the `credentials` Django app.
+"""
+import logging
+
+from django.contrib.auth import get_user_model
+from django.dispatch import receiver
+from openedx_events.learning.data import CertificateData
+from openedx_events.learning.signals import CERTIFICATE_CREATED
+
+from credentials.apps.core.api import get_or_create_user_from_event_data
+from credentials.apps.credentials.api import award_course_certificate
+
+
+User = get_user_model()
+logger = logging.getLogger(__name__)
+
+
+@receiver(CERTIFICATE_CREATED)
+def award_certificate_from_event(sender, **kwargs):  # pylint: disable=unused-argument
+    """
+    When we get a signal indicating that a certificate was created in the LMS, make sure to award a course certificate
+    UserCredential to the user in Credentials as well.
+
+    Args:
+        kwargs: event data sent with signal
+    """
+    certificate_data = kwargs.get("certificate", None)
+    if not certificate_data or not isinstance(certificate_data, CertificateData):
+        logger.error("Received null or unexpected data type from CERTIFICATE_CREATED signal")
+        return
+
+    course_event_data = certificate_data.course
+    user_event_data = certificate_data.user
+
+    user, __ = get_or_create_user_from_event_data(user_event_data)
+    if user:
+        logger.info(f"Awarding a course certificate to user [{user.id}] in course run [{course_event_data.course_key}]")
+        award_course_certificate(user, str(course_event_data.course_key), certificate_data.mode)
+    else:
+        logger.error(
+            f"Failed to award a course certificate to user with (LMS) user id [{user_event_data.id}] in course run "
+            f"[{course_event_data.course_key}]. Could not retrieve or create a user in Credentials associated with the "
+            "given user"
+        )
+        return

--- a/credentials/apps/credentials/tests/test_api.py
+++ b/credentials/apps/credentials/tests/test_api.py
@@ -1,5 +1,10 @@
+from unittest.mock import patch
+
+import ddt
+from ddt import unpack
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
+from testfixtures import LogCapture
 
 from credentials.apps.catalog.tests.factories import (
     CourseFactory,
@@ -10,11 +15,17 @@ from credentials.apps.catalog.tests.factories import (
 from credentials.apps.core.tests.factories import UserFactory
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.api import (
+    _get_course_run,
+    _update_or_create_credential,
+    award_course_certificate,
+    create_course_cert_config,
+    get_course_cert_config,
     get_course_certificates_with_ids,
     get_program_certificates_with_ids,
     get_user_credentials_by_content_type,
 )
 from credentials.apps.credentials.data import UserCredentialStatus
+from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate, UserCredential
 from credentials.apps.credentials.tests.factories import (
     CourseCertificateFactory,
     ProgramCertificateFactory,
@@ -212,3 +223,299 @@ class GetUserCredentialsByContentTypeTests(SiteMixin, TestCase):
         assert result[0] == self.course_user_credentials[0]
         assert result[1] == self.course_user_credentials[1]
         assert result[2] == self.program_user_credential
+
+
+class GetCourseRunTests(SiteMixin, TestCase):
+    """
+    Tests for the `_get_course_run` utility function.
+    """
+
+    def test_get_existing_course_run(self):
+        """
+        Happy path. This test ensures that we can retrieve a course run instance when using the `_get_course_run`
+        function.
+        """
+        course_run = CourseRunFactory()
+
+        expected_message = f"Attempting to retrieve course run with key [{course_run.key}]"
+
+        with LogCapture() as log:
+            result = _get_course_run(course_run.key)
+
+        assert result.key == course_run.key
+        assert result.id == course_run.id
+        assert log.records[0].msg == expected_message
+
+    def test_get_course_run_dne(self):
+        """
+        This test verifies the expected behavior of the `_get_course_run` function when we cannot find the course run
+        requested.
+        """
+        course_run_key = "blub/blub/glub"
+        expected_messages = [
+            f"Attempting to retrieve course run with key [{course_run_key}]",
+            f"Could not retrieve a course run with key [{course_run_key}]",
+        ]
+
+        with LogCapture() as log:
+            result = _get_course_run(course_run_key)
+
+        assert result is None
+        for index, message in enumerate(expected_messages):
+            assert message in log.records[index].getMessage()
+
+
+@ddt.ddt
+class UpdateOrCreateCredentialTests(SiteMixin, TestCase):
+    """
+    Tests for the `_update_or_create_credential` utility function.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.org = OrganizationFactory(site=self.site)
+        self.course = CourseFactory.create(site=self.site)
+        self.course_run = CourseRunFactory.create(course=self.course)
+        self.course_cert_config = CourseCertificateFactory.create(
+            course_id=self.course.id, course_run=self.course_run, site=self.site
+        )
+        self.program = ProgramFactory(
+            title="TestProgram1", course_runs=[self.course_run], authoring_organizations=[self.org], site=self.site
+        )
+        self.program_cert_config = ProgramCertificateFactory.create(program_uuid=self.program.uuid, site=self.site)
+
+    @ddt.data(
+        [CourseCertificate, UserCredentialStatus.AWARDED],
+        [CourseCertificate, UserCredentialStatus.REVOKED],
+        [ProgramCertificate, UserCredentialStatus.AWARDED],
+        [ProgramCertificate, UserCredentialStatus.REVOKED],
+    )
+    @unpack
+    def test_create_credential(self, credential_type, cert_status):
+        """
+        Happy path. This test verifies the functionality of the `_update_or_create_credentials` utility function.
+        Ensures that we can create a UserCredential of the appropriate type based on the data passed to the function.
+        """
+        with LogCapture() as log:
+            if credential_type is CourseCertificate:
+                cert, created = _update_or_create_credential(
+                    self.user.username, credential_type, self.course_cert_config.id, cert_status
+                )
+            else:
+                cert, created = _update_or_create_credential(
+                    self.user.username, credential_type, self.program_cert_config.id, cert_status
+                )
+
+        expected_message = (
+            f"Processed credential for user [{self.user.username}] with status [{cert_status}]. UUID: [{cert.uuid}], "
+            f"created: [{created}]"
+        )
+
+        assert cert.status == cert_status
+        assert log.records[0].msg == expected_message
+
+    def test_create_credential_exception_occurs(self):
+        """
+        This test verifies the behavior of the `_update_or_create_credentials` utility function when an exception
+        occurs.
+        """
+        with LogCapture() as log:
+            cert, created = _update_or_create_credential(
+                self.user.username, None, self.course_cert_config.id, UserCredentialStatus.AWARDED
+            )
+
+        expected_message = (
+            f"Error occurred processing a credential with credential_id [{self.course_cert_config.id}] for user "
+            f"[{self.user.username}]"
+        )
+
+        assert cert is None
+        assert created is None
+        assert log.records[0].msg == expected_message
+
+
+class GetOrCreateCertConfigTests(SiteMixin, TestCase):
+    """
+    Tests for the the Python API functions that deal with retrieving or creating course certificate configurations.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course = CourseFactory.create(site=self.site)
+        self.course_run = CourseRunFactory.create(course=self.course)
+
+    def test_get_course_cert_config(self):
+        """
+        Happy path. This test case verifies that we can retrieve an existing CourseCertificate instance when calling the
+        `get_course_cert_config` function.
+        """
+        course_cert_config = CourseCertificateFactory.create(
+            course_id=self.course.id, course_run=self.course_run, site=self.site
+        )
+
+        expected_message = (
+            f"Attempting to retrieve the course certificate configuration for course run [{self.course_run.key}]"
+        )
+
+        with LogCapture() as log:
+            course_cert = get_course_cert_config(self.course_run, "honor")
+
+        assert course_cert.course_id == str(self.course.id)
+        assert course_cert.course_run == self.course_run
+        assert course_cert.id == course_cert_config.id
+        assert log.records[0].msg == expected_message
+
+    @patch("credentials.apps.credentials.api.create_course_cert_config")
+    def test_get_course_cert_config_dne(self, mock_create):
+        """
+        This test case verifies the behavior of the `get_course_cert_config` function when the requested course
+        certificate does not exist.
+        """
+        expected_messages = [
+            f"Attempting to retrieve the course certificate configuration for course run [{self.course_run.key}]",
+            f"A course certificate configuration could not be found for course run [{self.course_run.key}]",
+        ]
+
+        with LogCapture() as log:
+            course_cert = get_course_cert_config(self.course_run, "honor")
+
+        assert course_cert is None
+        mock_create.assert_not_called()
+        for index, message in enumerate(expected_messages):
+            assert message in log.records[index].getMessage()
+
+    @patch("credentials.apps.credentials.api.create_course_cert_config")
+    def test_get_course_cert_config_dne_attempt_create(self, mock_create):
+        """
+        This test case verifies the behavior of the `get_course_cert_config` function when the requested course
+        certificate does not exist. It also verifies that we will attempt to create the course certificate instance.
+        """
+        expected_messages = [
+            f"Attempting to retrieve the course certificate configuration for course run [{self.course_run.key}]",
+            f"A course certificate configuration could not be found for course run [{self.course_run.key}]",
+        ]
+
+        with LogCapture() as log:
+            get_course_cert_config(self.course_run, "honor", create=True)
+
+        mock_create.assert_called_once_with(self.course_run, self.site, "honor")
+        for index, message in enumerate(expected_messages):
+            assert message in log.records[index].getMessage()
+
+    def test_create_course_cert_config(self):
+        """
+        Happy path. This test verifies that we can create a CourseCertificate instance with the information provided by
+        the function call using the `create_course_cert_config` function.
+        """
+        expected_message = f"Creating a course certificate configuration for course run [{self.course_run.key}]"
+
+        with LogCapture() as log:
+            course_cert = create_course_cert_config(self.course_run, self.site, "verified")
+
+        assert course_cert.course_id == self.course_run.key
+        assert course_cert.course_run == self.course_run
+        assert course_cert.certificate_type == "verified"
+        assert log.records[0].msg == expected_message
+
+    def test_create_course_cert_config_exception_occurs(self):
+        """
+        This test verifies the functionality of the `create_course_cert_config` function when we fail to create a course
+        cert configuration from the data provided.
+        """
+        expected_messages = [
+            f"Creating a course certificate configuration for course run [{self.course_run.key}]",
+            f"Error occurred creating a CourseCertificate configuration for course run [{self.course_run.key}]",
+        ]
+
+        with LogCapture() as log:
+            course_cert = create_course_cert_config(self.course_run, self.site, None)
+
+        assert course_cert is None
+        for index, message in enumerate(expected_messages):
+            assert message in log.records[index].getMessage()
+
+
+class AwardCourseCertificateTests(SiteMixin, TestCase):
+    """
+    Test cases for the `award_course_certificate` utility function.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.org = OrganizationFactory(site=self.site)
+        self.course = CourseFactory.create(site=self.site)
+        self.course_run = CourseRunFactory.create(course=self.course)
+
+    def test_award_course_cert(self):
+        """
+        Happy path. Verifies that we can award a UserCredential to a learner from event data consumed from the event
+        bus.
+        """
+        course_cert_config = CourseCertificateFactory.create(
+            course_id=self.course.id, course_run=self.course_run, site=self.site
+        )
+
+        award_course_certificate(self.user, self.course_run.key, "honor")
+        credential = UserCredential.objects.get(username=self.user.username, credential_id=course_cert_config.id)
+
+        assert credential.username == self.user.username
+        assert credential.credential_id == course_cert_config.id
+        assert credential.status == "awarded"
+        assert credential.credential_content_type_id == 12  # 12 is the content type for "Course Certificate"
+
+    def test_award_course_cert_no_course_run(self):
+        """
+        This test case verifies the expected behavior of the `award_course_certificate` function if a course run
+        received from an event does not exist in Credentials.
+        """
+        course_run_key = "course-v1:lol-doesnt-exist"
+        expected_messages = [
+            f"Attempting to retrieve course run with key [{course_run_key}]",
+            f"Could not retrieve a course run with key [{course_run_key}]",
+            f"Error awarding a course certificate to user [{self.user.id}] in course run [{course_run_key}]. Could not "
+            f"find a course run with key [{course_run_key}]",
+        ]
+
+        with LogCapture() as log:
+            award_course_certificate(self.user, course_run_key, "honor")
+
+        for index, message in enumerate(expected_messages):
+            assert message in log.records[index].getMessage()
+
+    def test_award_course_cert_no_course_certificate(self):
+        """
+        This test case verifies the expected behavior of the `award_course_certificate` function if a course cert
+        configuration doesn't exist for the course run.
+        """
+        award_course_certificate(self.user, self.course_run.key, "honor")
+
+        course_cert_config = CourseCertificate.objects.get(course_run=self.course_run, certificate_type="honor")
+        credential = UserCredential.objects.get(username=self.user.username, credential_id=course_cert_config.id)
+
+        assert credential.username == self.user.username
+        assert credential.credential_id == course_cert_config.id
+        assert credential.status == "awarded"
+        assert credential.credential_content_type_id == 12  # 12 is the content type for "Course Certificate"
+
+    def test_award_course_cert_no_course_certificate_exception_occurs(self):
+        """
+        This test case verifies the expected behavior of the `award_course_certificate` function if a course cert
+        configuration doesn't exist, but an exception occurs when we try to create it on the fly.
+        """
+        expected_messages = [
+            f"Attempting to retrieve course run with key [{self.course_run.key}]",
+            f"Attempting to retrieve the course certificate configuration for course run [{self.course_run.key}]",
+            f"A course certificate configuration could not be found for course run [{self.course_run.key}]",
+            f"Creating a course certificate configuration for course run [{self.course_run.key}]",
+            f"Error occurred creating a CourseCertificate configuration for course run [{self.course_run.key}]",
+            f"Error awarding a course certificate to user [{self.user.id}] in course run [{self.course_run.key}]. "
+            "A course certificate configuration could not be found or created.",
+        ]
+
+        with LogCapture() as log:
+            award_course_certificate(self.user, self.course_run.key, None)
+
+        for index, message in enumerate(expected_messages):
+            assert message in log.records[index].getMessage()

--- a/credentials/apps/credentials/tests/test_signals.py
+++ b/credentials/apps/credentials/tests/test_signals.py
@@ -1,0 +1,103 @@
+"""
+Tests for the `signals.py` file of the Credentials Django app.
+"""
+from datetime import datetime, timezone
+from unittest.mock import patch
+from uuid import uuid4
+
+import ddt
+from django.test import TestCase
+from openedx_events.data import EventsMetadata
+from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
+from openedx_events.learning.signals import CERTIFICATE_CREATED
+from testfixtures import LogCapture
+
+from credentials.apps.core.tests.factories import UserFactory
+from credentials.apps.credentials.signals import award_certificate_from_event
+
+
+@ddt.ddt
+class CertificateCreatedSignalTests(TestCase):
+    """
+    Tests for consuming `CERTIFICATE_CREATED` events from the event bus.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory()
+        self.course_key = "course-v1:commander101+1T2023"
+        self.mode = "verified"
+        self.certificate_data = CertificateData(
+            user=UserData(
+                pii=UserPersonalData(
+                    username=self.user.username,
+                    email=self.user.email,
+                    name=f"{self.user.first_name} {self.user.last_name}",
+                ),
+                id=self.user.lms_user_id,
+                is_active=True,
+            ),
+            course=CourseData(
+                course_key=self.course_key,
+            ),
+            mode=self.mode,
+            grade="1.0",
+            current_status="downloadable",
+            download_url="http://blah.blah.blah/certificate/1",
+            name="hypnofrog",
+        )
+        self.event_metadata = EventsMetadata(
+            event_type=CERTIFICATE_CREATED.event_type,
+            id=uuid4(),
+            minorversion=0,
+            source="openedx/lms/web",
+            sourcehost="lms.test",
+            time=datetime.now(timezone.utc),
+        )
+        self.event_data = {"certificate": self.certificate_data, "metadata": self.event_metadata}
+
+    @patch("credentials.apps.credentials.signals.award_course_certificate")
+    def test_certificate_created_user_exists(self, mock_award):
+        """
+        Happy path. This test verifies the ability to extract required data from a `CERTIFICATE_CREATED` event consumed
+        from the event bus. It then verifies the data passed to the `award_certificate_from_event` utility function
+        matches what we would expect.
+        """
+        expected_log_message = (
+            f"Awarding a course certificate to user [{self.user.id}] in course run [{self.course_key}]"
+        )
+
+        with LogCapture() as log:
+            award_certificate_from_event(None, **self.event_data)
+
+        mock_award.assert_called_once_with(self.user, self.course_key, "verified")
+        assert log.records[0].msg == expected_log_message
+
+    @patch("credentials.apps.credentials.signals.get_or_create_user_from_event_data", return_value=(None, None))
+    def test_certificate_exception_occurs(self, mock_get_user):  # pylint: disable=unused-argument
+        """
+        This test verifies the behavior of the `award_certificate_from_event` function if an unexpected exception occurs
+        when trying to retrieve (or create) a user while processing a `CERTIFICATE_CREATED` event from the event bus.
+        """
+        expected_log_message = (
+            f"Failed to award a course certificate to user with (LMS) user id [{self.user.lms_user_id}] in course run "
+            f"[{self.course_key}]. Could not retrieve or create a user in Credentials associated with the given user"
+        )
+
+        with LogCapture() as log:
+            award_certificate_from_event(None, **self.event_data)
+
+        assert log.records[0].msg == expected_log_message
+
+    @ddt.data({}, {"certificate": True})
+    def test_bad_data_type_passed_to_signal(self, bad_event_data):
+        """
+        This test verifies the behavior of the `award_certificate_from_event` function when unexpected data is passed
+        to the function.
+        """
+        expected_log_message = "Received null or unexpected data type from CERTIFICATE_CREATED signal"
+
+        with LogCapture() as log:
+            award_certificate_from_event(None, **bad_event_data)
+
+        assert log.records[0].msg == expected_log_message


### PR DESCRIPTION
[APER-2345]

Adds support for Credentials to consume the `CERTIFICATE_CREATED` event from the event bus.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
