### PR TITLE
fix: pinning `urllib3` package to fix update requirements workflow

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -31,3 +31,7 @@ sphinx<6.0
 # Pinning analytics-python to 1.4.0 to avoid an undocumented update to the project (w/ version number `1.4.post1`?).
 # It looks like we should be migrating to the 2.x version of the library (whose name has changed).
 analytics-python<=1.4.0
+
+# Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
+# APER-2422
+urllib3<2


### PR DESCRIPTION
We need to add a new constraint as `boto` is looking for versions of `urllib3` < 2.x.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
