### PR TITLE
chore: pin edx-event-bus-kafka to 3.9.6 to avoid breaking changes

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -43,11 +43,11 @@ bleach==6.0.0
     #   -r requirements/production.txt
 bok-choy==2.0.2
     # via -r requirements/dev.txt
-boto3==1.26.131
+boto3==1.26.133
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.29.131
+botocore==1.29.133
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -293,8 +293,9 @@ edx-drf-extensions==8.7.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-event-bus-kafka==3.10.0
+edx-event-bus-kafka==3.9.6
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
 edx-i18n-tools==0.9.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -149,8 +149,10 @@ edx-django-utils==5.4.0
     #   edx-toggles
 edx-drf-extensions==8.7.0
     # via -r requirements/base.in
-edx-event-bus-kafka==3.10.0
-    # via -r requirements/base.in
+edx-event-bus-kafka==3.9.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via edx-credentials-themes
 edx-opaque-keys[django]==2.3.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,3 +35,6 @@ analytics-python<=1.4.0
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2
+
+# edx-event-bus-kafka has breaking changes in 4.x, pin to 3.9.6 until we can consume the latest version
+edx-event-bus-kafka==3.9.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -216,8 +216,10 @@ edx-django-utils==5.4.0
     #   edx-toggles
 edx-drf-extensions==8.7.0
     # via -r requirements/test.txt
-edx-event-bus-kafka==3.10.0
-    # via -r requirements/test.txt
+edx-event-bus-kafka==3.9.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/dev.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -23,9 +23,9 @@ backoff==1.10.0
     #   analytics-python
 bleach==6.0.0
     # via -r requirements/base.txt
-boto3==1.26.131
+boto3==1.26.133
     # via django-ses
-botocore==1.29.131
+botocore==1.29.133
     # via
     #   boto3
     #   s3transfer
@@ -179,8 +179,10 @@ edx-django-utils==5.4.0
     #   edx-toggles
 edx-drf-extensions==8.7.0
     # via -r requirements/base.txt
-edx-event-bus-kafka==3.10.0
-    # via -r requirements/base.txt
+edx-event-bus-kafka==3.9.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -192,8 +192,10 @@ edx-django-utils==5.4.0
     #   edx-toggles
 edx-drf-extensions==8.7.0
     # via -r requirements/base.txt
-edx-event-bus-kafka==3.10.0
-    # via -r requirements/base.txt
+edx-event-bus-kafka==3.9.6
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
Pinning the version of edx-event-bus-kafka until we can update Credentials to work with the latest version and its breaking changes.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
