### PR TITLE
feat: Management command to sync LMS user ids

### DIFF
--- a/credentials/apps/core/management/commands/sync_ids_from_platform.py
+++ b/credentials/apps/core/management/commands/sync_ids_from_platform.py
@@ -57,10 +57,6 @@ class Command(BaseCommand):
         if 0 == limit:
             count = num_users_to_update
 
-        if count == 0:
-            logger.warning("No users to update. Stopping")
-            return
-
         logger.warning(f"Start processing {count} IDs with no lms_user_id")
 
         # loop over users in batches
@@ -72,10 +68,7 @@ class Command(BaseCommand):
             for user in curr_users:
                 # did the endpoint return a value for this user?
                 if user.username in ids:
-                    try:
-                        self.update_user(user, ids[user.username], verbosity, dry_run)
-                    except RuntimeError as err:
-                        logger.error(f"Error occurred when updating lms_user_id for user {user.username}: {err}")
+                    self.update_user(user, ids[user.username], verbosity, dry_run)
                 else:
                     logger.error(f"Could not get lms_user_id for user {user.username}")
             if x + slice_size < count:

--- a/credentials/apps/core/management/commands/sync_ids_from_platform.py
+++ b/credentials/apps/core/management/commands/sync_ids_from_platform.py
@@ -1,0 +1,105 @@
+"""
+Django managment command to sync missing lms user ids from platform
+"""
+
+import logging
+import time
+from urllib.parse import urljoin
+from urllib.error import HTTPError
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from credentials.apps.core.models import SiteConfiguration
+
+User = get_user_model()
+logger = logging.getLogger(__name__)
+
+site_configs = SiteConfiguration.objects.first()
+
+class Command(BaseCommand):
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch_size", 
+            type=int, 
+            default=10, 
+            help="Number of IDs to process at a time. Default 10")
+        parser.add_argument(
+            "--pause_ms", 
+            type=int, 
+            default=1, 
+            help="Number of seconds to pause between calls. Default 1 sec")
+        parser.add_argument(
+            "--limit", 
+            type=int, 
+            default=0, 
+            help="Total number of IDs to update. 0 for update all, Default is 0 (all)")
+
+    def handle(self, *args, **options):
+        """
+            Get batches of user info from accounts and update the lms_user_id
+            for users who are missing it.
+        """
+        users_without_lms_id = User.objects.filter(lms_user_id=None)
+        num_users_to_update = users_without_lms_id.count()
+        offset = options.get("batch_size")
+        pause = options.get("pause_ms")
+        count = options.get("limit")
+        # Get the actual number of users to process, an arg of 0 means all of them
+        count = min(count, num_users_to_update)
+        if (0 == count):
+            count = num_users_to_update
+               
+        if count == 0:
+            logger.warn("No users to update. Stopping")
+            return
+
+        logger.warn(f"Start processing {count} IDs with no lms_user_id")
+
+        # loop over users in batches    
+        for x in range(0, count, offset):
+            # don't go past the end of the loop
+            slice_size = min(count, x+offset)
+            curr_users = users_without_lms_id[x: slice_size]
+            ids = self.get_lms_ids(curr_users)
+            for user in curr_users:
+                try:
+                    self.update_user(user, ids[user.username])
+                except:
+                    logger.error(f"Could not update lms_user_id for user {user.username}")
+            if x + slice_size < count:
+                time.sleep(pause)
+        else:
+            logger.warn("sync_ids_from_platform finished!")
+        
+
+    def get_lms_ids(self, users):
+        """
+        given a list of users, query platform and get lms_user_ids
+        return a dict of lms_user_ids keyed by username
+        """
+        user_dict = dict()
+        # create a comma separated string with the usernames
+        user_name_list = ','.join(user.username for user in users)
+        user_url = urljoin(site_configs.user_api_url, f"accounts?username={user_name_list}")
+        try:
+            user_response = site_configs.api_client.get(user_url)
+            user_response.raise_for_status()
+            user_data = user_response.json()
+
+            for user_profile in user_data:
+                user_dict[user_profile["username"]] = user_profile["id"]
+        except HTTPError as http_error:
+            logger.error(f"An HTTP error occurred {http_error}")
+
+        return user_dict    
+
+    def update_user(self, user, id):
+        """ update the lms_user_id for the user """
+        if id and id > 0:
+            user.lms_user_id = id
+            user.save(update_fields=['lms_user_id'])
+
+
+
+

--- a/credentials/apps/core/management/commands/sync_ids_from_platform.py
+++ b/credentials/apps/core/management/commands/sync_ids_from_platform.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("--batch_size", type=int, default=10, help="Number of IDs to process at a time. Default 10")
         parser.add_argument(
-            "--pause_ms", type=int, default=1, help="Number of seconds to pause between calls. Default 1 sec"
+            "--pause_secs", type=int, default=1, help="Number of seconds to pause between calls. Default 1 sec"
         )
         parser.add_argument(
             "--limit", type=int, default=100, help="Total number of IDs to update. 0 for update all, Default is 100"
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         users_without_lms_id = User.objects.filter(lms_user_id=None)
         num_users_to_update = users_without_lms_id.count()
         offset = options.get("batch_size")
-        pause = options.get("pause_ms")
+        pause = options.get("pause_secs")
         limit = options.get("limit")
         verbosity = options.get("verbose")
         site_id = options.get("site_id")
@@ -48,7 +48,7 @@ class Command(BaseCommand):
         # This is likely rare
         if site_id:
             logger.info(f"using site id {site_id} for user queries")
-            site_configs = SiteConfiguration.objects.filter(site__id=site_id)
+            site_configs = SiteConfiguration.objects.get(site__id=site_id)
 
         logger.info(f"using {site_configs.site.domain} for user queries")
 

--- a/credentials/apps/core/management/commands/tests/test_sync_ids_from_platform.py
+++ b/credentials/apps/core/management/commands/tests/test_sync_ids_from_platform.py
@@ -1,0 +1,81 @@
+"""
+Tests for the sync_lms_user_ids management command
+"""
+import json
+
+import responses
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+from credentials.apps.core.tests.factories import UserFactory
+from credentials.apps.core.tests.mixins import SiteMixin
+
+
+User = get_user_model()
+
+JSON = "application/json"
+
+
+class LmsIdSyncTests(SiteMixin, TestCase):
+    def setUp(self):
+        """
+        Create users with no lms_id
+        """
+        super().setUp()
+        self.user = UserFactory(is_superuser=True)
+
+    def mock_account_api_response(self, status=200):
+        url = self.site.siteconfiguration.user_api_url + "accounts"
+        body = [{"username": "user1", "id": 1}]
+        responses.add(
+            responses.GET,
+            url,
+            body=json.dumps(body),
+            content_type=JSON,
+            status=status,
+            match_querystring=False,
+        )
+
+    @responses.activate
+    def test_update_ids(self):
+        """verify all ids were updated"""
+        UserFactory(username="user1", lms_user_id=None)
+
+        self.mock_access_token_response()
+        self.mock_account_api_response()
+        call_command("sync_ids_from_platform", verbose=True)
+
+        user = User.objects.get(lms_user_id=1)
+        print(f"fetched user: {user.username}, id {user.lms_user_id}")
+        self.assertEqual(user.username, "user1")
+        self.assertEqual(user.lms_user_id, 1, "User ID was not updated")
+
+    @responses.activate
+    def test_update_site(self):
+        """verify all ids were updated"""
+        UserFactory(username="user1", lms_user_id=None)
+
+        self.mock_access_token_response()
+        self.mock_account_api_response()
+        print(f"\n\n==>  site_id from configuration: {self.site_configuration.site_id}/n/n")
+        call_command("sync_ids_from_platform", verbose=True, site_id=self.site_configuration.site_id)
+
+        user = User.objects.get(lms_user_id=1)
+        print(f"fetched user: {user.username}, id {user.lms_user_id}")
+        self.assertEqual(user.username, "user1")
+        self.assertEqual(user.lms_user_id, 1, "User ID was not updated")
+
+    @responses.activate
+    def test_dry_run(self):
+        """verify ids were NOT updated"""
+        UserFactory(username="user1", lms_user_id=None)
+
+        self.mock_access_token_response()
+        self.mock_account_api_response()
+        call_command("sync_ids_from_platform", dry_run=True, verbose=True, limit=0)
+
+        user = User.objects.get(username="user1")
+        print(f"fetched user: {user.username}, id {user.lms_user_id}")
+        self.assertEqual(user.username, "user1")
+        self.assertEqual(user.lms_user_id, None, "User ID was updated in dry_run")

--- a/credentials/apps/core/management/commands/tests/test_sync_ids_from_platform.py
+++ b/credentials/apps/core/management/commands/tests/test_sync_ids_from_platform.py
@@ -1,10 +1,7 @@
 """
 Tests for the sync_lms_user_ids management command
 """
-from io import StringIO 
 import json
-import random
-from urllib.parse import urljoin
 
 import responses
 from django.contrib.auth import get_user_model
@@ -40,8 +37,6 @@ class LmsIdSyncTests(SiteMixin, TestCase):
             match_querystring=False,
         )
 
-
-
     @responses.activate
     def test_update_ids(self):
         """verify all ids were updated"""
@@ -58,17 +53,20 @@ class LmsIdSyncTests(SiteMixin, TestCase):
 
     @responses.activate
     def test_update_ids_404(self):
-        UserFactory(username="user1", lms_user_id=None)
-        """verify all ids were updated"""
+        user = UserFactory(username="user1", lms_user_id=None)
 
         self.mock_access_token_response()
         user_url = self.site.siteconfiguration.user_api_url + "accounts"
-        responses.add(responses.GET, user_url, content_type=JSON, status=404, match_querystring=False,)
-        try:
-            call_command("sync_ids_from_platform", verbose=True)
-        except:
-            self.assertTrue("call should not throw exception")
- 
+        responses.add(
+            responses.GET,
+            user_url,
+            content_type=JSON,
+            status=404,
+            match_querystring=False,
+        )
+        self.assertEqual(user.username, "user1")
+        self.assertEqual(user.lms_user_id, None, "User ID was updated unexpectedly")
+
     @responses.activate
     def test_update_site(self):
         """verify all ids were updated"""


### PR DESCRIPTION
This PR creates a management command that loops over all of the users in Credentials that don't have LMS user ids, fetches them from the LMS, and updates them in Credentials.
This will backfill all of the missing IDs that predate the update to collect LMS ids when data is pushed to Credentials.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
