### PR TITLE
fix: unpin edx-event-bus-kafka and fix breaking changes

### DIFF
--- a/credentials/apps/credentials/management/commands/consume_events.py
+++ b/credentials/apps/credentials/management/commands/consume_events.py
@@ -1,7 +1,0 @@
-"""
-Import the `consume_events` management command from the `event-bus-kafka` package in order to expose it here.
-
-This copies the approach currently used by the Discovery IDA.
-"""
-# pylint: disable=unused-import
-from edx_event_bus_kafka.management.commands.consume_events import Command

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -63,6 +63,7 @@ THIRD_PARTY_APPS = [
     "drf_yasg",
     "hijack",
     "xss_utils",
+    "openedx_events",
 ]
 
 PROJECT_APPS = [

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -9,7 +9,7 @@ analytics-python==1.4.0
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-asgiref==3.6.0
+asgiref==3.7.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -43,11 +43,11 @@ bleach==6.0.0
     #   -r requirements/production.txt
 bok-choy==2.0.2
     # via -r requirements/dev.txt
-boto3==1.26.134
+boto3==1.26.138
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.29.134
+botocore==1.29.138
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -200,7 +200,7 @@ django-rest-swagger==2.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-django-ses==3.4.1
+django-ses==3.5.0
     # via -r requirements/production.txt
 django-simple-history==3.0.0
     # via
@@ -226,7 +226,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.1
+django-webpack-loader==2.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -289,13 +289,12 @@ edx-django-utils==5.4.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-event-bus-kafka==3.9.6
+edx-event-bus-kafka==5.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
 edx-i18n-tools==0.9.2
@@ -311,7 +310,7 @@ edx-opaque-keys[django]==2.3.0
     #   -r requirements/production.txt
     #   edx-drf-extensions
     #   openedx-events
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -326,7 +325,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/dev.txt
-faker==18.7.0
+faker==18.9.0
     # via
     #   -r requirements/dev.txt
     #   factory-boy
@@ -340,11 +339,6 @@ filelock==3.12.0
     #   -r requirements/dev.txt
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/dev.txt
-    #   -r requirements/production.txt
-    #   pyjwkest
 gevent==22.10.2
     # via -r requirements/production.txt
 greenlet==2.0.2
@@ -450,7 +444,7 @@ openapi-codec==1.3.2
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django-rest-swagger
-openedx-events==7.3.0
+openedx-events==8.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -516,20 +510,10 @@ pycparser==2.21
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/dev.txt
-    #   -r requirements/production.txt
-    #   pyjwkest
 pygments==2.15.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/dev.txt
-    #   -r requirements/production.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/dev.txt
@@ -554,7 +538,7 @@ pylint-django==2.5.3
     # via
     #   -r requirements/dev.txt
     #   edx-lint
-pylint-plugin-utils==0.8.1
+pylint-plugin-utils==0.8.2
     # via
     #   -r requirements/dev.txt
     #   pylint-celery
@@ -627,7 +611,7 @@ pyyaml==5.4.1
     #   edx-django-release-util
     #   edx-i18n-tools
     #   responses
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -637,7 +621,6 @@ requests==2.30.0
     #   docker-compose
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   responses
     #   sailthru-client
@@ -697,7 +680,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   jsonschema
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
     #   tox
@@ -758,13 +740,15 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/dev.txt
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via
     #   -r requirements/dev.txt
     #   responses
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via
     #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   asgiref
     #   astroid
     #   black
     #   pylint
@@ -774,7 +758,7 @@ uritemplate==4.1.1
     #   -r requirements/production.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ analytics-python==1.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-asgiref==3.6.0
+asgiref==3.7.0
     # via django
 attrs==23.1.0
     # via
@@ -117,7 +117,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.1
+django-webpack-loader==2.0.0
     # via -r requirements/base.in
 djangorestframework==3.14.0
     # via
@@ -147,12 +147,10 @@ edx-django-utils==5.4.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via -r requirements/base.in
-edx-event-bus-kafka==3.9.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+edx-event-bus-kafka==5.1.0
+    # via -r requirements/base.in
 edx-i18n-tools==0.9.2
     # via edx-credentials-themes
 edx-opaque-keys[django]==2.3.0
@@ -160,7 +158,7 @@ edx-opaque-keys[django]==2.3.0
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   openedx-events
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/base.in
 edx-toggles==5.0.0
     # via
@@ -168,8 +166,6 @@ edx-toggles==5.0.0
     #   edx-event-bus-kafka
 fastavro==1.7.4
     # via openedx-events
-future==0.18.3
-    # via pyjwkest
 idna==3.4
     # via requests
 importlib-metadata==6.6.0
@@ -200,7 +196,7 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
-openedx-events==7.3.0
+openedx-events==8.0.0
     # via edx-event-bus-kafka
 packaging==23.1
     # via drf-yasg
@@ -216,12 +212,8 @@ psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
-pycryptodomex==3.17
-    # via pyjwkest
 pygments==2.15.1
     # via -r requirements/base.in
-pyjwkest==1.4.2
-    # via edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   drf-jwt
@@ -256,14 +248,13 @@ pyyaml==5.4.1
     #   code-annotations
     #   edx-django-release-util
     #   edx-i18n-tools
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   analytics-python
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   sailthru-client
     #   slumber
@@ -290,7 +281,6 @@ six==1.16.0
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
 slumber==0.7.1
@@ -313,11 +303,13 @@ stevedore==5.1.0
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
+typing-extensions==4.6.0
+    # via asgiref
 uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   requests

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -3,6 +3,11 @@
 # See BOM-2721 for more details.
 # Below is the copied and edited version of common_constraints
 
+# This is a temporary solution to override the real common_constraints.txt
+# In edx-lint, until the pyjwt constraint in edx-lint has been removed.
+# See BOM-2721 for more details.
+# Below is the copied and edited version of common_constraints
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,6 +35,3 @@ analytics-python<=1.4.0
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2
-
-# edx-event-bus-kafka has breaking changes in 4.x, pin to 3.9.6 until we can consume the latest version
-edx-event-bus-kafka==3.9.6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ analytics-python==1.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-asgiref==3.6.0
+asgiref==3.7.0
     # via
     #   -r requirements/test.txt
     #   django
@@ -174,7 +174,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.1
+django-webpack-loader==2.0.0
     # via -r requirements/test.txt
 djangorestframework==3.14.0
     # via
@@ -214,12 +214,10 @@ edx-django-utils==5.4.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via -r requirements/test.txt
-edx-event-bus-kafka==3.9.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+edx-event-bus-kafka==5.1.0
+    # via -r requirements/test.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/dev.in
@@ -232,7 +230,7 @@ edx-opaque-keys[django]==2.3.0
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   openedx-events
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/test.txt
 edx-toggles==5.0.0
     # via
@@ -244,7 +242,7 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.7.0
+faker==18.9.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -257,10 +255,6 @@ filelock==3.12.0
     #   -r requirements/test.txt
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/test.txt
-    #   pyjwkest
 httpretty==1.1.4
     # via -r requirements/test.txt
 idna==3.4
@@ -335,7 +329,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
-openedx-events==7.3.0
+openedx-events==8.0.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -390,16 +384,8 @@ pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/test.txt
-    #   pyjwkest
 pygments==2.15.1
     # via -r requirements/test.txt
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/test.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/test.txt
@@ -423,7 +409,7 @@ pylint-django==2.5.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
-pylint-plugin-utils==0.8.1
+pylint-plugin-utils==0.8.2
     # via
     #   -r requirements/test.txt
     #   pylint-celery
@@ -481,7 +467,7 @@ pyyaml==5.4.1
     #   edx-django-release-util
     #   edx-i18n-tools
     #   responses
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/test.txt
     #   analytics-python
@@ -490,7 +476,6 @@ requests==2.30.0
     #   docker-compose
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   responses
     #   sailthru-client
@@ -539,7 +524,6 @@ six==1.16.0
     #   edx-drf-extensions
     #   edx-lint
     #   jsonschema
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
     #   tox
@@ -592,13 +576,14 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.txt
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via
     #   -r requirements/test.txt
     #   responses
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via
     #   -r requirements/test.txt
+    #   asgiref
     #   astroid
     #   black
     #   pylint
@@ -607,7 +592,7 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -24,7 +24,7 @@ importlib-metadata==6.6.0
     # via sphinx
 jinja2==3.1.2
     # via sphinx
-jsx-lexer==2.0.0
+jsx-lexer==2.0.1
     # via -r requirements/docs.in
 markupsafe==2.1.2
     # via jinja2
@@ -36,7 +36,7 @@ pygments==2.15.1
     #   sphinx
 pytz==2023.3
     # via babel
-requests==2.30.0
+requests==2.31.0
     # via sphinx
 six==1.16.0
     # via edx-sphinx-theme
@@ -60,7 +60,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.40.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==23.1.2
     # via -r requirements/pip.in
-setuptools==67.7.2
+setuptools==67.8.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,7 +8,7 @@ analytics-python==1.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-asgiref==3.6.0
+asgiref==3.7.0
     # via
     #   -r requirements/base.txt
     #   django
@@ -23,9 +23,9 @@ backoff==1.10.0
     #   analytics-python
 bleach==6.0.0
     # via -r requirements/base.txt
-boto3==1.26.134
+boto3==1.26.138
     # via django-ses
-botocore==1.29.134
+botocore==1.29.138
     # via
     #   boto3
     #   s3transfer
@@ -127,7 +127,7 @@ django-ratelimit==3.0.1
     #   -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
-django-ses==3.4.1
+django-ses==3.5.0
     # via -r requirements/production.in
 django-simple-history==3.0.0
     # via
@@ -145,7 +145,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.1
+django-webpack-loader==2.0.0
     # via -r requirements/base.txt
 djangorestframework==3.14.0
     # via
@@ -177,12 +177,10 @@ edx-django-utils==5.4.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via -r requirements/base.txt
-edx-event-bus-kafka==3.9.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+edx-event-bus-kafka==5.1.0
+    # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/base.txt
@@ -192,7 +190,7 @@ edx-opaque-keys[django]==2.3.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   openedx-events
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/base.txt
 edx-toggles==5.0.0
     # via
@@ -202,10 +200,6 @@ fastavro==1.7.4
     # via
     #   -r requirements/base.txt
     #   openedx-events
-future==0.18.3
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
 gevent==22.10.2
     # via -r requirements/production.in
 greenlet==2.0.2
@@ -265,7 +259,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==7.3.0
+openedx-events==8.0.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -295,16 +289,8 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
 pygments==2.15.1
     # via -r requirements/base.txt
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/base.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -353,14 +339,13 @@ pyyaml==5.4.1
     #   code-annotations
     #   edx-django-release-util
     #   edx-i18n-tools
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   sailthru-client
     #   slumber
@@ -401,7 +386,6 @@ six==1.16.0
     #   edx-auth-backends
     #   edx-django-release-util
     #   edx-drf-extensions
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
 slumber==0.7.1
@@ -432,12 +416,16 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
+typing-extensions==4.6.0
+    # via
+    #   -r requirements/base.txt
+    #   asgiref
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,7 +8,7 @@ analytics-python==1.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-asgiref==3.6.0
+asgiref==3.7.0
     # via
     #   -r requirements/base.txt
     #   django
@@ -158,7 +158,7 @@ django-waffle==3.0.0
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-django-webpack-loader==1.8.1
+django-webpack-loader==2.0.0
     # via -r requirements/base.txt
 djangorestframework==3.14.0
     # via
@@ -190,12 +190,10 @@ edx-django-utils==5.4.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.7.0
+edx-drf-extensions==8.8.0
     # via -r requirements/base.txt
-edx-event-bus-kafka==3.9.6
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+edx-event-bus-kafka==5.1.0
+    # via -r requirements/base.txt
 edx-i18n-tools==0.9.2
     # via
     #   -r requirements/base.txt
@@ -207,7 +205,7 @@ edx-opaque-keys[django]==2.3.0
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   openedx-events
-edx-rest-api-client==5.5.1
+edx-rest-api-client==5.5.2
     # via -r requirements/base.txt
 edx-toggles==5.0.0
     # via
@@ -217,7 +215,7 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.7.0
+faker==18.9.0
     # via factory-boy
 fastavro==1.7.4
     # via
@@ -227,10 +225,6 @@ filelock==3.12.0
     # via
     #   tox
     #   virtualenv
-future==0.18.3
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
 httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.4
@@ -293,7 +287,7 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
-openedx-events==7.3.0
+openedx-events==8.0.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -339,16 +333,8 @@ pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
-pycryptodomex==3.17
-    # via
-    #   -r requirements/base.txt
-    #   pyjwkest
 pygments==2.15.1
     # via -r requirements/base.txt
-pyjwkest==1.4.2
-    # via
-    #   -r requirements/base.txt
-    #   edx-drf-extensions
 pyjwt[crypto]==2.7.0
     # via
     #   -r requirements/base.txt
@@ -367,7 +353,7 @@ pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
     # via edx-lint
-pylint-plugin-utils==0.8.1
+pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
@@ -416,14 +402,13 @@ pyyaml==5.4.1
     #   edx-django-release-util
     #   edx-i18n-tools
     #   responses
-requests==2.30.0
+requests==2.31.0
     # via
     #   -r requirements/base.txt
     #   analytics-python
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwkest
     #   requests-oauthlib
     #   responses
     #   sailthru-client
@@ -468,7 +453,6 @@ six==1.16.0
     #   edx-django-release-util
     #   edx-drf-extensions
     #   edx-lint
-    #   pyjwkest
     #   python-dateutil
     #   python-memcached
     #   tox
@@ -514,10 +498,12 @@ tox==3.28.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/test.in
-types-pyyaml==6.0.12.9
+types-pyyaml==6.0.12.10
     # via responses
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via
+    #   -r requirements/base.txt
+    #   asgiref
     #   astroid
     #   black
     #   pylint
@@ -526,7 +512,7 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.15
+urllib3==1.26.16
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.6.0
+asgiref==3.7.0
     # via django
 django==3.2.19
     # via
@@ -25,3 +25,5 @@ pyyaml==5.4.1
     #   edx-i18n-tools
 sqlparse==0.4.4
     # via django
+typing-extensions==4.6.0
+    # via asgiref


### PR DESCRIPTION
[APER-2438]

- unpin `edx-event-bus-kafka` (ebk) and update dependencies to pull in latest version of ebk
- remove the local `consume_events.py` as it is no longer needed
- adds `openedx_events` as a third party app to Credentials

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
