### PR TITLE
feat: add course_runs option in learner status API

### DIFF
--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -1,10 +1,10 @@
 import json
+from enum import Enum
 from unittest import mock
 
 import ddt
 from django.contrib.auth.models import Permission
 from django.urls import reverse
-from enum import Enum
 from rest_framework.test import APIRequestFactory, APITestCase
 
 from credentials.apps.api.tests.mixins import JwtMixin

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -105,21 +105,6 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
 
         return data, expected_response
 
-    @ddt.data(
-        (IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade),
-        (IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade),
-        (IdType.username, CredIdType.course_uuid, GradeType.grade),
-        (IdType.username, CredIdType.course_run_key, GradeType.grade),
-    )
-    @ddt.unpack
-    def test_post_positive(self, id_type, cred_type, grade_type):
-        """Test the iterations of id and course-run vs course"""
-        data, expected_response = self.create_credential(id_type, cred_type, grade_type)
-        response = self.call_api(self.user, data)
-        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-
-        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
-
     def test_coverage(self):
         data, expected_response = self.create_credential(
             IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade
@@ -128,12 +113,19 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
         self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
-        data, expected_response = self.create_credential(IdType.lms_user_id, CredIdType.course_uuid, GradeType.grade)
+        data, expected_response = self.create_credential(
+            IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade
+        )
         response = self.call_api(self.user, data)
         self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
-        data, expected_response = self.create_credential(IdType.lms_user_id, CredIdType.course_run_key, GradeType.grade)
+        data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_uuid, GradeType.grade)
+        response = self.call_api(self.user, data)
+        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+        data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_key, GradeType.grade)
         response = self.call_api(self.user, data)
         self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -105,30 +105,45 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
 
         return data, expected_response
 
-    def test_coverage(self):
-        data, expected_response = self.create_credential(
-            IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade
-        )
+    @ddt.data(
+        (IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade),
+        (IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade),
+        (IdType.username, CredIdType.course_uuid, GradeType.grade),
+        (IdType.username, CredIdType.course_run_key, GradeType.grade),
+    )
+    @ddt.unpack
+    def test_post_positive(self, id_type, cred_type, grade_type):
+        """Test the iterations of id and course-run vs course"""
+        data, expected_response = self.create_credential(id_type, cred_type, grade_type)
         response = self.call_api(self.user, data)
         self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
-        data, expected_response = self.create_credential(
-            IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade
-        )
-        response = self.call_api(self.user, data)
-        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+    # def test_coverage(self):
+    #     data, expected_response = self.create_credential(
+    #         IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade
+    #     )
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
-        data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_uuid, GradeType.grade)
-        response = self.call_api(self.user, data)
-        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+    #     data, expected_response = self.create_credential(
+    #         IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade
+    #     )
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
-        data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_key, GradeType.grade)
-        response = self.call_api(self.user, data)
-        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+    #     data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_uuid, GradeType.grade)
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+    #     data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_key, GradeType.grade)
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
     def test_unknown_user(self):
         data, expected_response = self.create_credential()  # pylint: disable=unused-variable

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -3,12 +3,10 @@ from enum import Enum
 from unittest import mock
 
 import ddt
-from django.contrib.auth.models import Permission
 from django.urls import reverse
-from rest_framework.test import APIRequestFactory, APITestCase
+from rest_framework.test import APITestCase
 
 from credentials.apps.api.tests.mixins import JwtMixin
-from credentials.apps.api.v2.serializers import UserCredentialSerializer
 from credentials.apps.catalog.tests.factories import CourseRunFactory
 from credentials.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from credentials.apps.core.tests.mixins import SiteMixin

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -42,15 +42,6 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
         self.client.logout()
         self.client.login(username=user.username, password=USER_PASSWORD)
 
-    def add_user_permission(self, user, permission):
-        """Assigns a permission of the given name to the user."""
-        user.user_permissions.add(Permission.objects.get(codename=permission))
-
-    def serialize_user_credential(self, user_credential, many=False):
-        """Serialize the given UserCredential object(s)."""
-        request = APIRequestFactory(SERVER_NAME=self.site.domain).get("/")
-        return UserCredentialSerializer(user_credential, context={"request": request}, many=many).data
-
     def build_jwt_headers(self, user):
         """
         Helper function for creating headers for the JWT authentication.

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -119,32 +119,7 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
         self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
 
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
-
-    # def test_coverage(self):
-    #     data, expected_response = self.create_credential(
-    #         IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade
-    #     )
-    #     response = self.call_api(self.user, data)
-    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
-
-    #     data, expected_response = self.create_credential(
-    #         IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade
-    #     )
-    #     response = self.call_api(self.user, data)
-    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
-
-    #     data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_uuid, GradeType.grade)
-    #     response = self.call_api(self.user, data)
-    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
-
-    #     data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_key, GradeType.grade)
-    #     response = self.call_api(self.user, data)
-    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
-    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
-
+ 
     def test_unknown_user(self):
         data, expected_response = self.create_credential()  # pylint: disable=unused-variable
         data["username"] = "unknown_user"

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -120,6 +120,24 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
 
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
 
+    def test_coverage(self):
+        data, expected_response = self.create_credential(
+            IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade
+        )
+        response = self.call_api(self.user, data)
+        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+        data, expected_response = self.create_credential(IdType.lms_user_id, CredIdType.course_uuid, GradeType.grade)
+        response = self.call_api(self.user, data)
+        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+        data, expected_response = self.create_credential(IdType.lms_user_id, CredIdType.course_run_key, GradeType.grade)
+        response = self.call_api(self.user, data)
+        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
     def test_unknown_user(self):
         data, expected_response = self.create_credential()  # pylint: disable=unused-variable
         data["username"] = "unknown_user"

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -43,6 +43,8 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
     def build_jwt_headers(self, user):
         """
         Helper function for creating headers for the JWT authentication.
+        Cloned and owned from elsewhere in the codebase, this should
+        be part of a utility somewhere.
         """
         jwt_payload = self.default_payload(user)
         token = self.generate_token(jwt_payload)
@@ -50,7 +52,9 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
         return headers
 
     def call_api(self, user, data):
-        """Helper function to call API with data"""
+        """
+        Helper function to call API with data
+        """
         data = json.dumps(data)
         headers = self.build_jwt_headers(user)
         return self.client.post(self.status_path, data, **headers, content_type=JSON_CONTENT_TYPE)
@@ -58,6 +62,9 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
     def create_credential(
         self, id_type=IdType.username, cred_id_type=CredIdType.course_uuid, grade_type=GradeType.grade
     ):
+        """
+        Create the payload for a request and also the expected response.
+        """
         course_run = CourseRunFactory.create()
         credential = CourseCertificateFactory.create(
             course_id=course_run.course.id, site=self.site, course_run=course_run
@@ -113,13 +120,43 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
     )
     @ddt.unpack
     def test_post_positive(self, id_type, cred_type, grade_type):
-        """Test the iterations of id and course-run vs course"""
+        """
+        Test the iterations of id and course-run vs course
+        """
         data, expected_response = self.create_credential(id_type, cred_type, grade_type)
         response = self.call_api(self.user, data)
         self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
 
         self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
- 
+
+    ## This is here as part of an experiment in code coverage. There appears to be a
+    ## difference in how the code is called and how coverage is calculated.
+
+    # def test_coverage(self):
+    #     data, expected_response = self.create_credential(
+    #         IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade
+    #     )
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+    #     data, expected_response = self.create_credential(
+    #         IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade
+    #     )
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+    #     data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_uuid, GradeType.grade)
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+    #     data, expected_response = self.create_credential(IdType.username, CredIdType.course_run_key, GradeType.grade)
+    #     response = self.call_api(self.user, data)
+    #     self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+    #     self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
     def test_unknown_user(self):
         data, expected_response = self.create_credential()  # pylint: disable=unused-variable
         data["username"] = "unknown_user"

--- a/credentials/apps/credentials/rest_api/v1/views.py
+++ b/credentials/apps/credentials/rest_api/v1/views.py
@@ -30,14 +30,19 @@ class LearnerCertificateStatusView(APIView):
         **POST Parameters**
 
         A POST request must include one of "lms_user_id" or "username",
-        and a list of course uuids
+        and a list of course uuids, course_runs, or a mix of both.
         (or a program uuid, in a future version)
 
         {
             "lms_user_id": <lms_id>,
             "courses": [
-                "uuid1",
-                "uuid2"
+                "course_uuid1",
+                "course_uuid2"
+                ...
+            ],
+            "course_runs": [
+                "course_run_uuid1",
+                "course_run_uuid2",
                 ...
             ]
         }
@@ -108,7 +113,9 @@ class LearnerCertificateStatusView(APIView):
 
         course_ids = request.data.get("courses")
 
-        courses = get_learner_course_run_status(username, course_ids)
+        course_runs = request.data.get("course_runs")
+
+        courses = get_learner_course_run_status(username, course_ids, course_runs)
 
         return Response(
             status=status.HTTP_200_OK,

--- a/credentials/apps/credentials/rest_api/v1/views.py
+++ b/credentials/apps/credentials/rest_api/v1/views.py
@@ -42,7 +42,7 @@ class LearnerCertificateStatusView(APIView):
             ],
             "course_runs": [
                 "course_run_uuid1",
-                "course_run_uuid2",
+                "course_run_key2",
                 ...
             ]
         }

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -328,7 +328,7 @@ def get_learner_course_run_status(username, course_ids, course_runs):
     courses = []
     keeper = False
     for credential in course_credentials:
-        if (course_ids):
+        if course_ids:
             if str(credential.credential.course_run.course.uuid) in course_ids:
                 keeper = True
         elif course_runs:
@@ -345,7 +345,7 @@ def get_learner_course_run_status(username, course_ids, course_runs):
             )
         ):
         """
-        
+
         if keeper:
             # we don't always have the grade, so defend for missing it
             try:

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -328,7 +328,11 @@ def get_learner_course_run_status(username, course_ids, course_runs):
     courses = []
     for credential in course_credentials:
         if (course_ids and (str(credential.credential.course_run.course.uuid) in course_ids)) or (
-            course_runs and (str(credential.credential.course_run.uuid) in course_runs)
+            course_runs
+            and (
+                (str(credential.credential.course_run.uuid) in course_runs)
+                or ((str(credential.credential.course_run.key) in course_runs))
+            )
         ):
             # we don't always have the grade, so defend for missing it
             try:

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -326,17 +326,7 @@ def get_learner_course_run_status(username, course_ids, course_runs):
     course_credentials, program_credentials = get_credentials(username)  # pylint: disable=unused-variable
 
     courses = []
-    keeper = False
     for credential in course_credentials:
-        if course_ids:
-            if str(credential.credential.course_run.course.uuid) in course_ids:
-                keeper = True
-        elif course_runs:
-            if str(credential.credential.course_run.uuid) in course_runs:
-                keeper = True
-            elif str(credential.credential.course_run.key) in course_runs:
-                keeper = True
-                """
         if (course_ids and (str(credential.credential.course_run.course.uuid) in course_ids)) or (
             course_runs
             and (
@@ -344,9 +334,6 @@ def get_learner_course_run_status(username, course_ids, course_runs):
                 or ((str(credential.credential.course_run.key) in course_runs))
             )
         ):
-        """
-
-        if keeper:
             # we don't always have the grade, so defend for missing it
             try:
                 grade = UserGrade.objects.get(username=username, course_run=credential.credential.course_run)

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -326,7 +326,17 @@ def get_learner_course_run_status(username, course_ids, course_runs):
     course_credentials, program_credentials = get_credentials(username)  # pylint: disable=unused-variable
 
     courses = []
+    keeper = False
     for credential in course_credentials:
+        if (course_ids):
+            if str(credential.credential.course_run.course.uuid) in course_ids:
+                keeper = True
+        elif course_runs:
+            if str(credential.credential.course_run.uuid) in course_runs:
+                keeper = True
+            elif str(credential.credential.course_run.key) in course_runs:
+                keeper = True
+                """
         if (course_ids and (str(credential.credential.course_run.course.uuid) in course_ids)) or (
             course_runs
             and (
@@ -334,6 +344,9 @@ def get_learner_course_run_status(username, course_ids, course_runs):
                 or ((str(credential.credential.course_run.key) in course_runs))
             )
         ):
+        """
+        
+        if keeper:
             # we don't always have the grade, so defend for missing it
             try:
                 grade = UserGrade.objects.get(username=username, course_run=credential.credential.course_run)

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -316,17 +316,20 @@ def get_program_details(request_user, request_site, uuid, is_public):
     }
 
 
-def get_learner_course_run_status(username, course_ids):
+def get_learner_course_run_status(username, course_ids, course_runs):
     """
-    Return the status for all of the course runs related to the courses in
-    the course uuid list for the given learner
+    Return the status for all of the related course runs related to the courses in
+    the course uuid list, plus any course_runs explicitly called out in the course_runs list
+    for the given learner.
     """
 
     course_credentials, program_credentials = get_credentials(username)  # pylint: disable=unused-variable
 
     courses = []
     for credential in course_credentials:
-        if str(credential.credential.course_run.course.uuid) in course_ids:
+        if (course_ids and (str(credential.credential.course_run.course.uuid) in course_ids)) or (
+            course_runs and (str(credential.credential.course_run.uuid) in course_runs)
+        ):
             # we don't always have the grade, so defend for missing it
             try:
                 grade = UserGrade.objects.get(username=username, course_run=credential.credential.course_run)


### PR DESCRIPTION
Add an optional section to the input payload for the learner status API which can provide a list of course-run UUIDS.
The API will handle either courses, course-runs, or a combination of both. (or none, but it won't do anything useful)
