### PR TITLE
Docker multi-arch images push for linux/amd64, linux/arm64

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,7 +1,6 @@
 name: Build and Push Docker Images
 
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -11,7 +11,7 @@ jobs:
   push:
     strategy:
       matrix:
-        build_platform: ["linux/arm64"]
+        build_platform: ["linux/amd64", "linux/arm64"]
     runs-on: ubuntu-latest
     # if: github.event_name == 'push'
 

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -49,13 +49,20 @@ jobs:
       #     repository: openedx/credentials
       #     tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+           registry: openedx/credentials-dev
+           username: ${{ secrets.DOCKERHUB_USERNAME }}
+           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v2
         with:
           push: ${{ github.event_name == 'pull_request' }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          # username: ${{ secrets.DOCKERHUB_USERNAME }}
+          # password: ${{ secrets.DOCKERHUB_PASSWORD }}
           target: dev
           repository: openedx/credentials-dev
           tags: "test"

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker Images
 
 on:
   pull_request:
-    
   push:
     branches:
       - master
@@ -35,7 +34,7 @@ jobs:
       #     result-encoding: string
 
       - name: Set up Docker Buildx
-          uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v1
         
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -9,9 +9,6 @@ on:
       - open-release/*
 jobs:  
   push:
-    strategy:
-      matrix:
-        build_platform: ["linux/amd64", "linux/arm64"]
     runs-on: ubuntu-latest
     # if: github.event_name == 'push'
 
@@ -65,5 +62,4 @@ jobs:
           target: dev
           # repository: openedx/credentials-dev
           tags: "openedx/credentials-dev:test"
-          platforms: |
-            ${{ matrix.build_platform }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           target: base
+          repository: openedx/credentials
           tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
           platforms: linux/amd64,linux/arm64
       
@@ -54,5 +55,6 @@ jobs:
         with:
           push: ${{ github.event_name != 'pull_request' }}
           target: dev
+          repository: openedx/credentials-dev
           tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+           username: ${{ secrets.DOCKERHUB_USERNAME }}
+           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       # - name: Build and push base Docker image
       #   uses: docker/build-push-action@v1
       #   with:
@@ -45,13 +51,6 @@ jobs:
       #     target: base
       #     repository: openedx/credentials
       #     tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-           username: ${{ secrets.DOCKERHUB_USERNAME }}
-           password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v2
@@ -60,6 +59,6 @@ jobs:
           # username: ${{ secrets.DOCKERHUB_USERNAME }}
           # password: ${{ secrets.DOCKERHUB_PASSWORD }}
           target: dev
-          # repository: openedx/credentials-dev
+          repository: openedx/credentials-dev
           tags: "openedx/credentials-dev:test"
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -42,7 +42,7 @@ jobs:
            password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
       - name: Build and push base Docker image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v4
         with:
           push: ${{ github.event_name != 'pull_request' }}
           target: base
@@ -50,7 +50,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
       
       - name: Build and push dev Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           push: ${{ github.event_name != 'pull_request' }}
           target: dev

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -34,10 +34,10 @@ jobs:
       #     result-encoding: string
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
         
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       # - name: Build and push base Docker image
       #   uses: docker/build-push-action@v1
@@ -51,7 +51,7 @@ jobs:
 
       
       - name: Build and push dev Docker image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v2
         with:
           push: ${{ github.event_name == 'pull_request' }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,15 +1,20 @@
 name: Build and Push Docker Images
 
 on:
+  pull_request:
+    
   push:
     branches:
       - master
     tags:
       - open-release/*
-jobs:
+jobs:  
   push:
+    strategy:
+      matrix:
+        build_platform: ["linux/amd64", "linux/arm64"]
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -18,33 +23,41 @@ jobs:
       # Use the release name as the image tag if we're building an open release tag.
       # Examples: if we're building 'open-release/maple.1', tag the image as 'maple.1'.
       # Otherwise, we must be building from a push to master, so use 'latest'.
-      - name: Get tag name
-        id: get-tag-name
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const releasePrefix = 'refs/tags/open-release/';
-            const tagName = context.ref.split(releasePrefix)[1] || 'latest';
-            console.log('Will use tag: ' + tagName);
-            return tagName;
-          result-encoding: string
+      # - name: Get tag name
+      #   id: get-tag-name
+      #   uses: actions/github-script@v6
+      #   with:
+      #     script: |
+      #       const releasePrefix = 'refs/tags/open-release/';
+      #       const tagName = context.ref.split(releasePrefix)[1] || 'latest';
+      #       console.log('Will use tag: ' + tagName);
+      #       return tagName;
+      #     result-encoding: string
 
-      - name: Build and push base Docker image
-        uses: docker/build-push-action@v1
-        with:
-          push: ${{ github.event_name != 'pull_request' }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-          target: base
-          repository: openedx/credentials
-          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+      - name: Set up Docker Buildx
+          uses: docker/setup-buildx-action@v1
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
+      # - name: Build and push base Docker image
+      #   uses: docker/build-push-action@v1
+      #   with:
+      #     push: ${{ github.event_name != 'pull_request' }}
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      #     target: base
+      #     repository: openedx/credentials
+      #     tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+
+      
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v1
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'pull_request' }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           target: dev
           repository: openedx/credentials-dev
-          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+          tags: "test"
+          platforms: ${{ matrix.build_platform }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:
-           registry: openedx/credentials-dev
            username: ${{ secrets.DOCKERHUB_USERNAME }}
            password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
@@ -64,7 +63,7 @@ jobs:
           # username: ${{ secrets.DOCKERHUB_USERNAME }}
           # password: ${{ secrets.DOCKERHUB_PASSWORD }}
           target: dev
-          repository: openedx/credentials-dev
-          tags: "test"
+          # repository: openedx/credentials-dev
+          tags: "openedx/credentials-dev:test"
           platforms: |
             ${{ matrix.build_platform }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -11,7 +11,7 @@ jobs:
   push:
     strategy:
       matrix:
-        build_platform: ["linux/arm64", "linux/amd64"]
+        build_platform: ["linux/arm64"]
     runs-on: ubuntu-latest
     # if: github.event_name == 'push'
 

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -59,4 +59,5 @@ jobs:
           target: dev
           repository: openedx/credentials-dev
           tags: "test"
-          platforms: ${{ matrix.build_platform }}
+          platforms: |
+            ${{ matrix.build_platform }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -10,7 +10,7 @@ on:
 jobs:  
   push:
     runs-on: ubuntu-latest
-    # if: github.event_name == 'push'
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout
@@ -19,16 +19,16 @@ jobs:
       # Use the release name as the image tag if we're building an open release tag.
       # Examples: if we're building 'open-release/maple.1', tag the image as 'maple.1'.
       # Otherwise, we must be building from a push to master, so use 'latest'.
-      # - name: Get tag name
-      #   id: get-tag-name
-      #   uses: actions/github-script@v6
-      #   with:
-      #     script: |
-      #       const releasePrefix = 'refs/tags/open-release/';
-      #       const tagName = context.ref.split(releasePrefix)[1] || 'latest';
-      #       console.log('Will use tag: ' + tagName);
-      #       return tagName;
-      #     result-encoding: string
+      - name: Get tag name
+        id: get-tag-name
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const releasePrefix = 'refs/tags/open-release/';
+            const tagName = context.ref.split(releasePrefix)[1] || 'latest';
+            console.log('Will use tag: ' + tagName);
+            return tagName;
+          result-encoding: string
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -42,23 +42,18 @@ jobs:
            username: ${{ secrets.DOCKERHUB_USERNAME }}
            password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # - name: Build and push base Docker image
-      #   uses: docker/build-push-action@v1
-      #   with:
-      #     push: ${{ github.event_name != 'pull_request' }}
-      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      #     target: base
-      #     repository: openedx/credentials
-      #     tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+      - name: Build and push base Docker image
+        uses: docker/build-push-action@v1
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          target: base
+          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
       
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v2
         with:
-          push: ${{ github.event_name == 'pull_request' }}
-          # username: ${{ secrets.DOCKERHUB_USERNAME }}
-          # password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          push: ${{ github.event_name != 'pull_request' }}
           target: dev
-          # repository: openedx/credentials-dev
-          tags: "openedx/credentials-dev:test"
+          tags: ${{ steps.get-tag-name.outputs.result }},${{ github.sha }}
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -11,7 +11,7 @@ jobs:
   push:
     strategy:
       matrix:
-        build_platform: ["linux/amd64", "linux/arm64"]
+        build_platform: ["linux/arm64", "linux/amd64"]
     runs-on: ubuntu-latest
     # if: github.event_name == 'push'
 

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -59,6 +59,6 @@ jobs:
           # username: ${{ secrets.DOCKERHUB_USERNAME }}
           # password: ${{ secrets.DOCKERHUB_PASSWORD }}
           target: dev
-          repository: openedx/credentials-dev
+          # repository: openedx/credentials-dev
           tags: "openedx/credentials-dev:test"
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
In this PR i updated github action to push multi-architecture(amd-64, arm-64) docker images on the docker hub. Now the M1/M2 apple machines would pull the arm-64 architecture docker images via devstack. 
