### PR TITLE
fix: correct use of `update_or_create` when updating existing credentials via event bus

### DIFF
--- a/credentials/apps/credentials/api.py
+++ b/credentials/apps/credentials/api.py
@@ -59,7 +59,10 @@ def _update_or_create_credential(username, credential_type, credential_id, statu
     try:
         content_type = ContentType.objects.get_for_model(credential_type)
         credential, created = _UserCredential.objects.update_or_create(
-            username=username, credential_content_type=content_type, credential_id=credential_id, status=status
+            username=username,
+            credential_content_type=content_type,
+            credential_id=credential_id,
+            defaults={"status": status},
         )
     except Exception:  # pylint: disable=broad-exception-caught
         logger.exception(

--- a/credentials/apps/credentials/tests/test_api.py
+++ b/credentials/apps/credentials/tests/test_api.py
@@ -465,6 +465,40 @@ class AwardCourseCertificateTests(SiteMixin, TestCase):
         assert credential.status == "awarded"
         assert credential.credential_content_type_id == 12  # 12 is the content type for "Course Certificate"
 
+    def test_update_existing_cert(self):
+        """
+        A unit test that verifies we can update an existing certificate record.
+        """
+        course_credential_content_type = ContentType.objects.get(app_label="credentials", model="coursecertificate")
+        course_cert_config = CourseCertificateFactory.create(
+            course_id=self.course.id, course_run=self.course_run, site=self.site
+        )
+        credential = UserCredentialFactory.create(
+            username=self.user.username,
+            credential_content_type=course_credential_content_type,
+            credential=course_cert_config,
+            status=UserCredential.REVOKED,
+        )
+        expected_message = (
+            f"Processed credential for user [{self.user.username}] with status [{UserCredential.AWARDED}]. UUID: "
+            f"[{credential.uuid}], created: [False]"
+        )
+
+        with LogCapture() as logs:
+            award_course_certificate(self.user, self.course_run.key, "honor")
+
+        credential = UserCredential.objects.get(
+            username=self.user.username,
+            credential_id=course_cert_config.id,
+            credential_content_type=course_credential_content_type,
+        )
+        log_messages = [log.msg for log in logs.records]
+
+        assert credential.username == self.user.username
+        assert credential.credential_id == course_cert_config.id
+        assert credential.status == "awarded"
+        assert expected_message in log_messages
+
     def test_award_course_cert_no_course_run(self):
         """
         This test case verifies the expected behavior of the `award_course_certificate` function if a course run


### PR DESCRIPTION
[APER-2505]

This PR corrects an error in the `_update_or_create_credential` function, which is invoked when processing `CERTIFICATE_CREATED` events from the event bus.

I had set the search criteria too strictly and didn't properly pass in a `defaults` dict with the data that should be updated if a match is found. This was resulting in a database IntegrityError because the ORM wasn't finding existing entities correctly and attempting to insert a new record that violated constraints on the table.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
