### PR TITLE
fix: fix lookup of `CourseCertificate` objects

### DIFF
--- a/credentials/apps/credentials/api.py
+++ b/credentials/apps/credentials/api.py
@@ -93,7 +93,7 @@ def get_course_cert_config(course_run, mode, create=False):
     course_cert_config = None
     try:
         logger.info(f"Attempting to retrieve the course certificate configuration for course run [{course_run.key}]")
-        course_cert_config = _CourseCertificate.objects.get(course_run=course_run)
+        course_cert_config = _CourseCertificate.objects.get(course_id=course_run.key)
     except _CourseCertificate.DoesNotExist:
         logger.error(f"A course certificate configuration could not be found for course run [{course_run.key}]")
     finally:

--- a/credentials/apps/credentials/tests/test_api.py
+++ b/credentials/apps/credentials/tests/test_api.py
@@ -351,7 +351,7 @@ class GetOrCreateCertConfigTests(SiteMixin, TestCase):
         `get_course_cert_config` function.
         """
         course_cert_config = CourseCertificateFactory.create(
-            course_id=self.course.id, course_run=self.course_run, site=self.site
+            course_id=self.course_run.key, course_run=self.course_run, site=self.site
         )
 
         expected_message = (
@@ -361,7 +361,7 @@ class GetOrCreateCertConfigTests(SiteMixin, TestCase):
         with LogCapture() as log:
             course_cert = get_course_cert_config(self.course_run, "honor")
 
-        assert course_cert.course_id == str(self.course.id)
+        assert course_cert.course_id == self.course_run.key
         assert course_cert.course_run == self.course_run
         assert course_cert.id == course_cert_config.id
         assert log.records[0].msg == expected_message
@@ -454,7 +454,7 @@ class AwardCourseCertificateTests(SiteMixin, TestCase):
         bus.
         """
         course_cert_config = CourseCertificateFactory.create(
-            course_id=self.course.id, course_run=self.course_run, site=self.site
+            course_id=self.course_run.key, course_run=self.course_run, site=self.site
         )
 
         award_course_certificate(self.user, self.course_run.key, "honor")
@@ -471,7 +471,7 @@ class AwardCourseCertificateTests(SiteMixin, TestCase):
         """
         course_credential_content_type = ContentType.objects.get(app_label="credentials", model="coursecertificate")
         course_cert_config = CourseCertificateFactory.create(
-            course_id=self.course.id, course_run=self.course_run, site=self.site
+            course_id=self.course_run.key, course_run=self.course_run, site=self.site
         )
         credential = UserCredentialFactory.create(
             username=self.user.username,


### PR DESCRIPTION
[APER-2505]

This PR fixes an issue that can come up when trying to retrieve an existing CourseCertificate object. Originally, we were using the `course_run` field to do the lookup but sometimes this data isn't set properly when it is created (which is a known issue and we're tracking this internally as APER-1777).

Instead, we should use the `course_id` field (which is really the course run key) to do the lookup.

This also fixes some errors in our unit tests that were setting the wrong data through use of our test data Factories.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
