### PR TITLE
fix: pin mysqlclient version

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -35,3 +35,6 @@ analytics-python<=1.4.0
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2
+
+# Pinning mysqlclient to version 2.1.1 as newer version was breaking our build. This constraint will be re-evaluted as part of APER-2556
+mysqlclient<=2.1.1


### PR DESCRIPTION
Pinning version of `mysqlclient` to v2.1.1. See [APER-2556](https://2u-internal.atlassian.net/browse/APER-2556) for more details and plan for follow up.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
