### PR TITLE
fix: update Dockerfile and unpin mysqlclient

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,25 @@
 FROM ubuntu:focal as base
 
-# Warning: This file is experimental.
-#
-# Short-term goals:
-# * Be a suitable replacement for the `edxops/credentials` image in devstack (in progress).
-# * Take advantage of Docker caching layers: aim to put commands in order of
-#   increasing cache-busting frequency.
-# * Related to ^, use no Ansible or Paver.
-# Long-term goal:
-# * Be a suitable base for production Credentials images. This may not yet be the case.
-
-# Packages installed:
-# git; Used to pull in particular requirements from github rather than pypi,
+# System requirements
+# - git; Used to pull in particular requirements from github rather than pypi,
 # and to check the sha of the code checkout.
-
-# language-pack-en locales; ubuntu locale support so that system utilities have a consistent
+# - language-pack-en locales; ubuntu locale support so that system utilities have a consistent
 # language and time zone.
-
-# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
-
-# python3-pip; install pip to install application requirements.txt files
-
-# libssl-dev; # mysqlclient wont install without this.
-
-# libmysqlclient-dev; to install header files needed to use native C implementation for
+# - python; ubuntu doesnt ship with python, so this is the python we will use to run the application
+# - python3-pip; install pip to install application requirements.txt files
+# - libssl-dev; # mysqlclient wont install without this.
+# - libmysqlclient-dev; to install header files needed to use native C implementation for
 # MySQL-python for performance gains.
-
-# wget to download a watchman binary archive
-
-# unzip to unzip a watchman binary archive
+# - wget; to download a watchman binary archive
+# - unzip; to unzip a watchman binary archive
+# - pkg-config; mysqlclient>=2.2.0 requires pkg-config (https://github.com/PyMySQL/mysqlclient/issues/620)
 
 # If you add a package here please include a comment above describing what it is used for
 RUN apt-get update && \
 apt-get install -y software-properties-common && \
 apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
 apt-get upgrade -qy && apt-get install language-pack-en locales git \
-python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip -qy && \
+python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip pkg-config -qy && \
 rm -rf /var/lib/apt/lists/*
 
 # Create Python env

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -43,11 +43,11 @@ bleach==6.0.0
     #   -r requirements/production.txt
 bok-choy==2.0.2
     # via -r requirements/dev.txt
-boto3==1.27.0
+boto3==1.27.1
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.30.0
+botocore==1.30.1
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -420,9 +420,8 @@ mypy-extensions==1.0.0
     # via
     #   -r requirements/dev.txt
     #   black
-mysqlclient==2.1.1
+mysqlclient==2.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
 newrelic==8.8.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -181,10 +181,8 @@ markupsafe==2.1.3
     # via jinja2
 monotonic==1.6
     # via analytics-python
-mysqlclient==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+mysqlclient==2.2.0
+    # via -r requirements/base.in
 newrelic==8.8.1
     # via
     #   -r requirements/base.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -36,9 +36,4 @@ analytics-python<=1.4.0
 # APER-2422
 urllib3<2
 
-
 django-simple-history<=3.1.1
-
-# Pinning mysqlclient to version 2.1.1 as newer version was breaking our build. This constraint will be re-evaluted as part of APER-2556
-mysqlclient<=2.1.1
-

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -312,10 +312,8 @@ mypy-extensions==1.0.0
     # via
     #   -r requirements/test.txt
     #   black
-mysqlclient==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+mysqlclient==2.2.0
+    # via -r requirements/test.txt
 newrelic==8.8.1
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -23,9 +23,9 @@ backoff==1.10.0
     #   analytics-python
 bleach==6.0.0
     # via -r requirements/base.txt
-boto3==1.27.0
+boto3==1.27.1
     # via django-ses
-botocore==1.30.0
+botocore==1.30.1
     # via
     #   boto3
     #   s3transfer
@@ -239,10 +239,8 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
-mysqlclient==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+mysqlclient==2.2.0
+    # via -r requirements/base.txt
 newrelic==8.8.1
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -270,10 +270,8 @@ monotonic==1.6
     #   analytics-python
 mypy-extensions==1.0.0
     # via black
-mysqlclient==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+mysqlclient==2.2.0
+    # via -r requirements/base.txt
 newrelic==8.8.1
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
[APER-2556]

This PR makes an update to the Credentials IDA's Dockerfile to install `pkg-config` which is required for `mysqlclient` v. 2.2.0+. This allow us to remove our constraint for the `mysqlclient` version installed with Credentials.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
