### PR TITLE
feat: add support for program certificate event bus events

### DIFF
--- a/credentials/apps/credentials/config.py
+++ b/credentials/apps/credentials/config.py
@@ -1,0 +1,34 @@
+"""
+This module contain configuration settings for the Credentials app.
+"""
+
+from edx_toggles.toggles import SettingToggle
+
+
+# .. toggle_name: SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: When True, the system will publish `PROGRAM_CERTIFICATE_AWARDED` signals to the event bus. The
+#   `PROGRAM_CERTIFICATE_AWARDED` signal is emit when a certificate has been awarded to a learner and the creation
+#   process has completed.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-08-07
+# .. toggle_target_removal_date: TBD
+# .. toggle_tickets: TODO
+SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL = SettingToggle(
+    "SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL", default=False, module_name=__name__
+)
+
+# .. toggle_name: SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL
+# .. toggle_implementation: SettingToggle
+# .. toggle_default: False
+# .. toggle_description: When True, the system will publish `PROGRAM_CERTIFICATE_REVOKED` signals to the event bus. The
+#   `PROGRAM_CERTIFICATE_REVOKED` signal is emit when the Credentials service has finished updating the learner's
+#   UserCredential instance.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-08-07
+# .. toggle_target_removal_date: TBD
+# .. toggle_tickets: TODO
+SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL = SettingToggle(
+    "SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL", default=False, module_name=__name__
+)

--- a/credentials/apps/credentials/signals.py
+++ b/credentials/apps/credentials/signals.py
@@ -3,10 +3,16 @@ Signal receivers for the `credentials` Django app.
 """
 import logging
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.dispatch import receiver
+from openedx_events.event_bus import get_producer
 from openedx_events.learning.data import CertificateData
-from openedx_events.learning.signals import CERTIFICATE_CREATED
+from openedx_events.learning.signals import (
+    CERTIFICATE_CREATED,
+    PROGRAM_CERTIFICATE_AWARDED,
+    PROGRAM_CERTIFICATE_REVOKED,
+)
 
 from credentials.apps.core.api import get_or_create_user_from_event_data
 from credentials.apps.credentials.api import award_course_certificate
@@ -44,3 +50,40 @@ def award_certificate_from_event(sender, **kwargs):  # pylint: disable=unused-ar
             "given user"
         )
         return
+
+
+@receiver(PROGRAM_CERTIFICATE_AWARDED)
+def listen_for_program_certificate_awarded_event(sender, signal, **kwargs):  # pylint: disable=unused-argument
+    """
+    Receiver for `PROGRAM_CERTIFICATE_AWARDED` events. This function is responsible for extracting required information
+    and passing it to another utility function responsible for publishing program certificate events to the event bus.
+    """
+    _publish_program_certificate_event(PROGRAM_CERTIFICATE_AWARDED, kwargs["program_certificate"], kwargs["metadata"])
+
+
+@receiver(PROGRAM_CERTIFICATE_REVOKED)
+def listen_for_program_certificate_revoked_event(sender, signal, **kwargs):  # pylint: disable=unused-argument
+    """
+    Receiver for `PROGRAM_CERTIFICATE_REVOKED` events. This function is responsible for extracting required information
+    and passing it to another utility function responsible for publishing program certificate events to the event bus.
+    """
+    _publish_program_certificate_event(PROGRAM_CERTIFICATE_REVOKED, kwargs["program_certificate"], kwargs["metadata"])
+
+
+def _publish_program_certificate_event(program_certificate_event_type, event_data, event_metadata):
+    """
+    Publishes Program Certificate lifecycle events to the event bus.
+
+    Args:
+        program_certificate_event_type (OpenEdxPublicSignal): The type of event we are publishing to the event bus
+         (e.g. PROGRAM_CERTIFICATE_AWARDED or PROGRAM_CERTIFICATE_REVOKED)
+        event_data (dict): Learner and credential data extracted from the event signal
+        event_metadata (dict): Event metadata extracted from the event signal
+    """
+    get_producer().send(
+        signal=program_certificate_event_type,
+        topic=getattr(settings, "PROGRAM_CERTIFICATE_EVENTS_KAFKA_TOPIC_NAME", ""),
+        event_key_field="program_certificate.program.uuid",
+        event_data={"program_certificate": event_data},
+        event_metadata=event_metadata,
+    )

--- a/credentials/apps/credentials/tests/factories.py
+++ b/credentials/apps/credentials/tests/factories.py
@@ -3,6 +3,7 @@ import uuid
 
 import factory
 
+from credentials.apps.catalog.tests.factories import ProgramFactory
 from credentials.apps.core.tests.factories import SiteFactory
 from credentials.apps.credentials import constants, models
 
@@ -30,7 +31,8 @@ class ProgramCertificateFactory(AbstractCertificateFactory):
         model = models.ProgramCertificate
 
     is_active = True
-    program_uuid = factory.LazyFunction(uuid.uuid4)
+    program = factory.SubFactory(ProgramFactory)
+    program_uuid = factory.SelfAttribute("program.uuid")
 
 
 class UserCredentialFactory(factory.django.DjangoModelFactory):

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -1,13 +1,18 @@
 """
-Tests for Issuer class.
+Tests for Issuer classes.
 """
 from unittest import mock
+from uuid import uuid4
 
+from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
+from openedx_events.learning.data import ProgramCertificateData, ProgramData, UserData, UserPersonalData
+from testfixtures import LogCapture
 
 from credentials.apps.api.exceptions import DuplicateAttributeError
 from credentials.apps.catalog.tests.factories import ProgramFactory
 from credentials.apps.core.tests.factories import SiteConfigurationFactory, SiteFactory, UserFactory
+from credentials.apps.credentials.constants import UserCredentialStatus
 from credentials.apps.credentials.issuers import CourseCertificateIssuer, ProgramCertificateIssuer
 from credentials.apps.credentials.models import (
     CourseCertificate,
@@ -18,12 +23,15 @@ from credentials.apps.credentials.models import (
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
 
 
+User = get_user_model()
 LOGGER_NAME = "credentials.apps.credentials.issuers"
 
 
 # pylint: disable=no-member
 class CertificateIssuerBase:
-    """Tests an Issuer class and its methods."""
+    """
+    Tests an Issuer class and its methods.
+    """
 
     issuer = None
     cert_factory = None
@@ -38,25 +46,31 @@ class CertificateIssuerBase:
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_issued_credential_type(self):
-        """Verify issued_credential_type returns the correct credential type."""
+        """
+        Verify issued_credential_type returns the correct credential type.
+        """
         self.assertEqual(self.issuer.issued_credential_type, self.cert_type)
 
     def test_issue_existing_credential(self):
-        """Verify credentials can be updated when re-issued."""
-
+        """
+        Verify credentials can be updated when re-issued.
+        """
         user_credential = self.issuer.issue_credential(self.certificate, self.username, "revoked")
         self.user_cred.refresh_from_db()
         self._assert_usercredential_fields(self.user_cred, self.certificate, self.username, "revoked", [])
         self.assertEqual(user_credential, self.user_cred)
 
     def test_issue_credential_without_attributes(self):
-        """Verify credentials can be issued without attributes."""
-
+        """
+        Verify credentials can be issued without attributes.
+        """
         user_credential = self.issuer.issue_credential(self.certificate, self.username)
         self._assert_usercredential_fields(user_credential, self.certificate, self.username, "awarded", [])
 
     def test_issue_credential_with_attributes(self):
-        """Verify credentials can be issued with attributes."""
+        """
+        Verify credentials can be issued with attributes.
+        """
         UserFactory(username="testuser2")
         user_credential = self.issuer.issue_credential(self.certificate, "testuser2", attributes=self.attributes)
         self._assert_usercredential_fields(user_credential, self.certificate, "testuser2", "awarded", self.attributes)
@@ -72,34 +86,35 @@ class CertificateIssuerBase:
         self.assertEqual(actual_attributes, expected_attrs)
 
     def test_set_credential_without_attributes(self):
-        """Verify that if no attributes given then None will return."""
+        """
+        Verify that if no attributes given then None will return.
+        """
         self.assertEqual(self.issuer.set_credential_attributes(self.user_cred, None), None)
 
     def test_set_credential_with_attributes(self):
-        """Verify that it adds the given attributes against user credential."""
-
+        """
+        Verify that the system can associate credential attributes with a learner's credential.
+        """
         self.issuer.set_credential_attributes(self.user_cred, self.attributes)
         self._assert_usercredential_fields(
             self.user_cred, self.certificate, self.user_cred.username, "awarded", self.attributes
         )
 
     def test_set_credential_with_duplicate_attributes_by_util(self):
-        """Verify in case of duplicate attributes utils method will return False and
-        exception will be raised.
         """
-
+        Verify that the application throws an exception is thrown if it encounters a duplicate attribute related to a
+        learner's credential.
+        """
         self.attributes.append({"name": "whitelist_reason", "value": "Reason for whitelisting."})
 
         with self.assertRaises(DuplicateAttributeError):
             self.issuer.set_credential_attributes(self.user_cred, self.attributes)
 
     def test_existing_credential_with_duplicate_attributes(self):
-        """Verify if user credential attributes already exists in db then method will
-        update existing attributes values."""
-
-        # add the attribute in db and then try to create the credential
-        # with same data "names but value is different"
-
+        """
+        Verify if user credential attributes already exists in db then method will update existing attributes values.
+        """
+        # add the attribute in db and then try to create the credential with same data "names but value is different"
         attribute_db = {"name": "whitelist_reason", "value": "Reason for whitelisting."}
 
         UserCredentialAttribute.objects.create(
@@ -113,8 +128,10 @@ class CertificateIssuerBase:
         )
 
     def test_existing_attributes_with_empty_attributes_list(self):
-        """Verify if user credential attributes already exists in db then in case of empty
-        attributes list it will return without changing any data."""
+        """
+        Verify if user credential attributes already exists in db then in case of empty attributes list it will return
+        without changing any data.
+        """
 
         self.issuer.set_credential_attributes(self.user_cred, self.attributes)
         self._assert_usercredential_fields(
@@ -129,7 +146,9 @@ class CertificateIssuerBase:
 
 
 class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
-    """Tests for program Issuer class and its methods."""
+    """
+    Tests for program Issuer class and its methods.
+    """
 
     issuer = ProgramCertificateIssuer()
     cert_factory = ProgramCertificateFactory
@@ -139,16 +158,18 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         super().setUp()
         self.site = SiteFactory()
         self.site_config = SiteConfigurationFactory(site=self.site)
-        self.program = ProgramFactory(site=self.site)
-        self.certificate = self.cert_factory.create(program_uuid=self.program.uuid, site=self.site)
+        self.program = ProgramFactory(site=self.site, uuid=uuid4())
+        self.certificate = self.cert_factory.create(
+            program_uuid=self.program.uuid, program=self.program, site=self.site
+        )
         self.username = "tester2"
         self.user = UserFactory(username=self.username)
         self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_records_enabled_is_unchecked(self):
-        """Verify that if SiteConfiguration.records_enabled is unchecked then don't send
-        updated email to a pathway org.
+        """
+        Verify that if SiteConfiguration.records_enabled is unchecked then don't send updated email to a pathway org.
         """
         self.site_config.records_enabled = False
         self.site_config.save()
@@ -158,8 +179,9 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
             self.assertEqual(mock_method.call_count, 0)
 
     def test_records_enabled_is_checked(self):
-        """Verify that if SiteConfiguration.records_enabled is checked and new record is created
-        then updated email is sent to a pathway org.
+        """
+        Verify that if SiteConfiguration.records_enabled is checked and new record is created then updated email is
+        sent to a pathway org.
         """
         with mock.patch("credentials.apps.credentials.issuers.send_updated_emails_for_program") as mock_method:
             self.issuer.issue_credential(self.certificate, "testuser4", attributes=self.attributes)
@@ -168,6 +190,10 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
     @override_settings(SEND_EMAIL_ON_PROGRAM_COMPLETION=True)
     @mock.patch("credentials.apps.credentials.issuers.send_program_certificate_created_message")
     def test_send_learner_email_when_issuing_program_cert(self, mock_send_learner_email):
+        """
+        Verify that the application sends a program completion email when a learner is issued a credential for the first
+        time.
+        """
         self.site_config.records_enabled = False
         self.site_config.save()
 
@@ -178,8 +204,8 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
     @mock.patch("credentials.apps.credentials.issuers.send_program_certificate_created_message")
     def test_send_learner_email_only_once(self, mock_send_learner_email):
         """
-        Verify that we call `send_program_certificate_created_message` only once if a
-        certificate already exists and is being awarded again after being revoked.
+        Verify that the application will not send additional program completion emails if the certificate is modified
+        after originally being issued.
         """
         username = "learner"
         user = UserFactory(username=username)
@@ -199,8 +225,7 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
     @mock.patch("credentials.apps.credentials.issuers.send_program_certificate_created_message")
     def test_do_not_send_learner_email_when_feature_disabled(self, mock_send_learner_email):
         """
-        Verify that we do NOT try to send an email to the learner when a Program Cert is issued
-        if the feature is disabled.
+        Verify that we don't try to send an updated program progress email when issuing an updated program credential.
         """
         self.site_config.records_enabled = False
         self.site_config.save()
@@ -208,9 +233,145 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         self.issuer.issue_credential(self.certificate, "testuser6")
         self.assertEqual(mock_send_learner_email.call_count, 0)
 
+    @mock.patch("credentials.apps.credentials.issuers.ProgramCertificateIssuer._emit_program_certificate_signal")
+    def test_publish_program_certificate_signal(self, mock_emit):
+        """
+        Verify that the ProgramCertificateIssuer makes a call to the `_emit_program_certificate_signal` function as
+        expected when the system creates or updates a UserCredential.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        user = UserFactory()
+        self.issuer.issue_credential(self.certificate, user.username)
+
+        # retrieve the credential generated for verifications
+        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+        assert mock_emit.call_count == 1
+        mock_emit.assert_called_with(user.username, user_credential, "awarded", self.certificate)
+
+    @override_settings(SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL=True)
+    @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_AWARDED.send_event")
+    def test_emit_program_certificate_signal_certificate_awarded(self, mock_send):
+        """
+        Verify that a `PROGRAM_CERTIFICATE_AWARDED` signal is emit when a program certificate is awarded to a learner.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        user = UserFactory()
+        self.issuer.issue_credential(self.certificate, user.username)
+        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+
+        expected_event_data = ProgramCertificateData(
+            user=UserData(
+                pii=UserPersonalData(username=user.username, email=user.email, name=user.get_full_name()),
+                id=user.lms_user_id,
+                is_active=user.is_active,
+            ),
+            program=ProgramData(
+                uuid=str(self.program.uuid), title=self.program.title, program_type=self.program.type_slug
+            ),
+            uuid=str(user_credential.uuid),
+            status="awarded",
+            url=f"https://{self.site.domain}/credentials/{str(user_credential.uuid).replace('-', '')}/",
+        )
+
+        assert mock_send.call_count == 1
+        mock_call_args = mock_send.mock_calls[0].kwargs
+        assert expected_event_data == mock_call_args["program_certificate"]
+
+    @override_settings(SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL=False)
+    @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_AWARDED.send_event")
+    def test_emit_program_certificate_signal_certificate_awarded_signal_disabled(self, mock_send):
+        """
+        Verify that a `PROGRAM_CERTIFICATE_AWARDED` signal is NOT emit if the `SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL`
+        feature flag is disabled.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        user = UserFactory()
+        self.issuer.issue_credential(self.certificate, user.username)
+        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+
+        assert user_credential
+        assert mock_send.call_count == 0
+
+    @override_settings(SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL=True)
+    @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_REVOKED.send_event")
+    def test_emit_program_certificate_signal_certificate_revoked(self, mock_send):
+        """
+        Verify that a `PROGRAM_CERTIFICATE_REVOKED` signal is emit when a program certificate is revoked from a learner.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        user = UserFactory()
+        self.issuer.issue_credential(self.certificate, user.username, UserCredentialStatus.REVOKED)
+        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+
+        expected_event_data = ProgramCertificateData(
+            user=UserData(
+                pii=UserPersonalData(username=user.username, email=user.email, name=user.get_full_name()),
+                id=user.lms_user_id,
+                is_active=user.is_active,
+            ),
+            program=ProgramData(
+                uuid=str(self.program.uuid), title=self.program.title, program_type=self.program.type_slug
+            ),
+            uuid=str(user_credential.uuid),
+            status="revoked",
+            url=f"https://{self.site.domain}/credentials/{str(user_credential.uuid).replace('-', '')}/",
+        )
+
+        assert mock_send.call_count == 1
+        mock_call_args = mock_send.mock_calls[0].kwargs
+        assert expected_event_data == mock_call_args["program_certificate"]
+
+    @override_settings(SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL=False)
+    @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_REVOKED.send_event")
+    def test_emit_program_certificate_signal_certificate_revoked_signal_disabled(self, mock_send):
+        """
+        Verify that a `PROGRAM_CERTIFICATE_REVOKED` signal is NOT emit if the `SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL`
+        feature flag is disabled.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        user = UserFactory()
+        self.issuer.issue_credential(self.certificate, user.username)
+        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+
+        assert user_credential
+        assert mock_send.call_count == 0
+
+    @override_settings(SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL=True)
+    @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_AWARDED.send_event")
+    def test_emit_program_certificate_signal_user_dne(self, mock_send):
+        """
+        Verify error handling and application behavior if the system cannot retrieve a user with the specified username
+        when attempting to send a program certificate event.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        expected_error_message = (
+            "Unable to send a program certificate event for user with username [mistadobalina]. No user found "
+            "matching this username"
+        )
+
+        with LogCapture() as log:
+            self.issuer.issue_credential(self.certificate, "mistadobalina")
+
+        assert expected_error_message in log.records[0].msg
+        assert mock_send.call_count == 0
+
 
 class CourseCertificateIssuerTests(CertificateIssuerBase, TestCase):
-    """Tests for course Issuer class and its methods."""
+    """
+    Tests for course Issuer class and its methods.
+    """
 
     issuer = CourseCertificateIssuer()
     cert_factory = CourseCertificateFactory

--- a/credentials/apps/credentials/tests/test_signals.py
+++ b/credentials/apps/credentials/tests/test_signals.py
@@ -6,14 +6,33 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import ddt
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from openedx_events.data import EventsMetadata
-from openedx_events.learning.data import CertificateData, CourseData, UserData, UserPersonalData
-from openedx_events.learning.signals import CERTIFICATE_CREATED
+from openedx_events.learning.data import (
+    CertificateData,
+    CourseData,
+    ProgramCertificateData,
+    ProgramData,
+    UserData,
+    UserPersonalData,
+)
+from openedx_events.learning.signals import (
+    CERTIFICATE_CREATED,
+    PROGRAM_CERTIFICATE_AWARDED,
+    PROGRAM_CERTIFICATE_REVOKED,
+)
 from testfixtures import LogCapture
 
-from credentials.apps.core.tests.factories import UserFactory
-from credentials.apps.credentials.signals import award_certificate_from_event
+from credentials.apps.catalog.tests.factories import ProgramFactory
+from credentials.apps.core.tests.factories import SiteConfigurationFactory, SiteFactory, UserFactory
+from credentials.apps.credentials.constants import UserCredentialStatus
+from credentials.apps.credentials.signals import (
+    _publish_program_certificate_event,
+    award_certificate_from_event,
+    listen_for_program_certificate_awarded_event,
+    listen_for_program_certificate_revoked_event,
+)
+from credentials.apps.credentials.tests.factories import ProgramCertificateFactory, UserCredentialFactory
 
 
 @ddt.ddt
@@ -101,3 +120,90 @@ class CertificateCreatedSignalTests(TestCase):
             award_certificate_from_event(None, **bad_event_data)
 
         assert log.records[0].msg == expected_log_message
+
+
+class ProgramCertificateEventLifecycleTests(TestCase):
+    """
+    Tests for publishing `PROGRAM_CERTIFICATE_AWARDED` and `PROGRAM_CERTIFICATE_REVOKED` events from the event bus.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.site = SiteFactory()
+        self.site_configuration = SiteConfigurationFactory()
+        self.program = ProgramFactory(site=self.site, uuid=uuid4())
+        self.certificate = ProgramCertificateFactory(
+            program_uuid=self.program.uuid,
+            program=self.program,
+            site=self.site,
+        )
+        self.user = UserFactory()
+        self.user_credential = UserCredentialFactory(username=self.user.username, credential=self.certificate)
+
+    def _create_program_certificate_event_data(self, status):
+        return ProgramCertificateData(
+            user=UserData(
+                pii=UserPersonalData(
+                    username=self.user.username, email=self.user.email, name=self.user.get_full_name()
+                ),
+                id=self.user.lms_user_id,
+                is_active=self.user.is_active,
+            ),
+            program=ProgramData(
+                uuid=str(self.program.uuid),
+                title=self.program.title,
+                program_type=self.program.type_slug,
+            ),
+            uuid=str(self.user_credential.uuid),
+            status=status,
+            url=f"https://{self.site.domain}/credentials/{str(self.user_credential.uuid).replace('-', '')}/",
+        )
+
+    def _create_event_metadata(self, event_type):
+        return EventsMetadata(
+            event_type=event_type.event_type,
+            id=uuid4(),
+            minorversion=0,
+            source="openedx/credentials",
+            sourcehost="credentials.test",
+            time=datetime.now(timezone.utc),
+        )
+
+    @patch("credentials.apps.credentials.signals._publish_program_certificate_event")
+    def test_listen_for_program_certificate_awarded_event(self, mock_publish):
+        program_certificate_event_data = self._create_program_certificate_event_data(UserCredentialStatus.AWARDED)
+        event_metadata = self._create_event_metadata(PROGRAM_CERTIFICATE_AWARDED)
+
+        event_data = {"program_certificate": program_certificate_event_data, "metadata": event_metadata}
+        listen_for_program_certificate_awarded_event(None, None, **event_data)
+
+        assert mock_publish.called_once_with(
+            PROGRAM_CERTIFICATE_AWARDED, program_certificate_event_data, event_metadata
+        )
+
+    @patch("credentials.apps.credentials.signals._publish_program_certificate_event")
+    def test_listen_for_program_certificate_revoked_event(self, mock_publish):
+        program_certificate_event_data = self._create_program_certificate_event_data(UserCredentialStatus.REVOKED)
+        event_metadata = self._create_event_metadata(PROGRAM_CERTIFICATE_REVOKED)
+
+        event_data = {"program_certificate": program_certificate_event_data, "metadata": event_metadata}
+        listen_for_program_certificate_revoked_event(None, None, **event_data)
+
+        assert mock_publish.called_once_with(
+            PROGRAM_CERTIFICATE_REVOKED, program_certificate_event_data, event_metadata
+        )
+
+    @patch("credentials.apps.credentials.signals.get_producer")
+    @override_settings(PROGRAM_CERTIFICATE_EVENTS_KAFKA_TOPIC_NAME="program-cert_publish_unit-test")
+    def test_publish_program_certificate(self, mock_producer):
+        program_certificate_event_data = self._create_program_certificate_event_data(UserCredentialStatus.AWARDED)
+        event_metadata = self._create_event_metadata(PROGRAM_CERTIFICATE_AWARDED)
+
+        _publish_program_certificate_event(PROGRAM_CERTIFICATE_AWARDED, program_certificate_event_data, event_metadata)
+
+        data = mock_producer.return_value.send.call_args.kwargs
+        assert data["signal"].event_type == PROGRAM_CERTIFICATE_AWARDED.event_type
+        assert data["event_data"]["program_certificate"] == program_certificate_event_data
+        assert data["topic"] == "program-cert_publish_unit-test"
+        assert data["event_key_field"] == "program_certificate.program.uuid"
+        assert data["event_metadata"] == event_metadata

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -550,3 +550,11 @@ add_plugins(__name__, PROJECT_TYPE, SettingsType.BASE)
 
 # disable indexing on history_date
 SIMPLE_HISTORY_DATE_INDEX = False
+
+# Event Bus Settings
+EVENT_BUS_PRODUCER = "edx_event_bus_redis.create_producer"
+EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
+EVENT_BUS_REDIS_CONNECTION_URL = "redis://:password@edx.devstack.redis:6379/"
+EVENT_BUS_TOPIC_PREFIX = "dev"
+
+PROGRAM_CERTIFICATE_EVENTS_KAFKA_TOPIC_NAME = "learning-program-certificate-lifecycle"


### PR DESCRIPTION
[APER-2626]

- Adds support for the `PROGRAM_CERTIFICATE_AWARDED` event, emit when a program certificate is generated for a learner
- Adds default settings for the (redis) event bus to `base.py`
- Adds unit tests for the `_emit_program_certificate_signal` function of `../credentials/issuers.py`
- Slight refactor of the `issue_credential` function for readability
- Add additional doc updates where possible
- Adds unit tests for the new signal receivers in `../credentials/signals.py`

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
