### PR TITLE
feat: add logging to Credentials grade endpoint

### DIFF
--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -282,6 +282,13 @@ class UserGradeSerializer(serializers.ModelSerializer):
             course_run=course_run,
             defaults=validated_data,
         )
+
+        logger.info(
+            f"Updated grade for user [{username}] in course [{course_run.key}] with percent_grade "
+            f"[{grade.percent_grade}], letter_grade [{grade.letter_grade}], verified [{grade.verified}], and "
+            f"lms_last_updated_at [{grade.lms_last_updated_at}]"
+        )
+
         return grade
 
 


### PR DESCRIPTION
[APER-2730]

It is difficult to determine exactly what is going wrong when grade data is different between the LMS and Credentials. This PR adds some logging to the `UserGradeSerializer` so that we have a bit more visibility into the updates being received from the LMS.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
