### PR TITLE
fix: add back in program record URL handling

### DIFF
--- a/credentials/apps/records/urls.py
+++ b/credentials/apps/records/urls.py
@@ -9,6 +9,10 @@ from . import views
 urlpatterns = [
     re_path(r"^$", views.RecordsView.as_view(), name="index"),
     re_path(r"^api/", include(("credentials.apps.records.rest_api.urls", "api"), namespace="api")),
+    # NOTE: We need to _keep_ this to ensure Program Dashboard can send the learner directly to the Program Record
+    re_path(
+        rf"^programs/{UUID_PATTERN}/$", views.ProgramRecordView.as_view(), {"is_public": False}, name="private_programs"
+    ),
     # NOTE: We need to _keep_ this to ensure shared public program records continue to work
     re_path(
         rf"^programs/shared/{UUID_PATTERN}/$",


### PR DESCRIPTION
### Context: 
The Program Dashboard from the LMS still uses a Credential URL path to allow users to view their Program Record. When the old Program Record view was deleted in #2104 , the URL path to `/records/programs/` was also removed, which prevented learners from viewing their Program Record through the Program Dashboard page. They were still able to see their record via the Profile MFE, because that path used the Learner Record MFE to view render the new Program Record page.  

### What this commit does:

 Bring back the URL path handler (`/records/programs/{PROGRAM_UUID}`)and redirect it to the Learner Record MFE's Program Record page. 

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
