### PR TITLE
feat: fixing an exceptional case

### DIFF
--- a/credentials/apps/credentials/management/commands/tests/test_populate_missing_courserun_info.py
+++ b/credentials/apps/credentials/management/commands/tests/test_populate_missing_courserun_info.py
@@ -2,6 +2,8 @@
 Tests for the populate_missing_courserun_info management command
 """
 
+from logging import INFO, WARNING
+
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
 from django.test import TestCase
@@ -33,6 +35,16 @@ class CourseCertificateCourseRunSyncTests(TestCase):
 
         course_cert = CourseCertificate.objects.get(course_run=self.course_run)
         self.assertEqual(course_cert.course_id, course_cert.course_run.key)
+
+    def test_when_course_run_not_in_catalog(self):
+        """verify it works when there's the problem course run isn't in the catalog"""
+        course_certificate = CourseCertificateFactory(course_id="I.dont.exist")
+
+        with self.assertLogs(level=INFO):
+            call_command("populate_missing_courserun_info", verbose=True)
+
+        # verify no changes were made
+        self.assertIsNone(course_certificate.course_run)
 
     def test_dry_run(self):
         """verify course_ids were NOT updated"""


### PR DESCRIPTION
When this code switched from using direct ORM calls to the catalog API, the exception handling that was there became meaningless and the error protection was no longer valid.

This fixes the code and adds a test case. While writing test cases to improve coverage for a few of the other exception handling cases, I realized that those exceptions were already handled by database constraints, so I removed the error handling code altogether.

FIXES: APER-2425

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
