### PR TITLE
feat: use `atlas` in `make pull_translations`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM ubuntu:focal as base
 RUN apt-get update && \
 apt-get install -y software-properties-common && \
 apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
-apt-get upgrade -qy && apt-get install language-pack-en locales git \
+apt-get upgrade -qy && apt-get install language-pack-en locales gettext git \
 python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip pkg-config -qy && \
 rm -rf /var/lib/apt/lists/*
 

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,19 @@ compile_translations: ## Compile translation files, outputting .mo files for eac
 fake_translations: extract_translations dummy_translations compile_translations ## Generate and compile dummy translation files
 
 # This Make target should not be removed since it is relied on by a Jenkins job (`edx-internal/tools-edx-jenkins/translation-jobs.yml`), using `ecommerce-scripts/transifex`.
+ifeq ($(OPENEDX_ATLAS_PULL),)
 pull_translations: ## Pull translations from Transifex
 	tx pull -t -a -f --mode reviewed --minimum-perc=1
+else
+# Experimental: OEP-58 Pulls translations using atlas
+pull_translations:
+	find credentials/conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+	atlas pull $(OPENEDX_ATLAS_ARGS) translations/credentials/credentials/conf/locale:credentials/conf/locale
+	python manage.py compilemessages
+
+	@echo "Translations have been pulled via Atlas and compiled."
+	@echo "'make static' or 'make static.dev' is required to update the js i18n files."
+endif
 
 # This Make target should not be removed since it is relied on by a Jenkins job (`edx-internal/tools-edx-jenkins/translation-jobs.yml`), using `ecommerce-scripts/transifex`.
 push_translations: ## Push source translation files (.po) to Transifex

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -442,6 +442,10 @@ openapi-codec==1.3.2
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django-rest-swagger
+openedx-atlas==0.4.4
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
 openedx-events==8.6.0
     # via
     #   -r requirements/dev.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -40,6 +40,7 @@ edx-toggles
 markdown
 mysqlclient
 newrelic
+openedx-atlas
 pillow
 pygments
 python-memcached

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -193,6 +193,8 @@ oauthlib==3.2.2
     #   social-auth-core
 openapi-codec==1.3.2
     # via django-rest-swagger
+openedx-atlas==0.4.4
+    # via -r requirements/base.in
 openedx-events==8.6.0
     # via edx-event-bus-kafka
 packaging==23.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -326,6 +326,8 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
+openedx-atlas==0.4.4
+    # via -r requirements/test.txt
 openedx-events==8.6.0
     # via
     #   -r requirements/test.txt

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -256,6 +256,8 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+openedx-atlas==0.4.4
+    # via -r requirements/base.txt
 openedx-events==8.6.0
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -284,6 +284,8 @@ openapi-codec==1.3.2
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
+openedx-atlas==0.4.4
+    # via -r requirements/base.txt
 openedx-events==8.6.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Changes

Install [`openedx-atlas`](https://github.com/openedx/openedx-atlas/#readme) as an alternative to Transifex `tx` client for managing translations when `OPENEDX_ATLAS_PULL` environment variable is set. This is similar to the [discovery atlas pull request](https://github.com/openedx/course-discovery/pull/4037).

### Testing

 - [x] Install atlas via `pip-tools`, but undo other packages upgrade to simulate `pip-tools --upgrade-package=openedx-atlas`
 - [x] Build the docker image
```
# Credentials repo
cd ~/work/openedx/credentials
docker build --target=dev -t edxops/credentials:latest .

# Devstack
cd ~/work/openedx/devstack
make dev.remove-containers.credentials
make dev.up.credentials

# Similar to `make dev.shell.credentials` but with custom commands
docker-compose exec credentials atlas --version
docker-compose exec credentials env OPENEDX_ATLAS_PULL=true make pull_translations static.dev
docker-compose exec credentials ls -R credentials/conf

# Reset the credentials container to the upstream image from Docker Hub
docker pull edxops/credentials:latest

# Get into the shell for manual testing
make dev.shell.credentials
```

 - [x] run `OPENEDX_ATLAS_PULL=true make pull_translations static.dev`

```
$ docker-compose exec credentials ls -R credentials/conf

credentials/conf:
locale

credentials/conf/locale:
config.yaml  en  fr_CA

credentials/conf/locale/en:
LC_MESSAGES

credentials/conf/locale/en/LC_MESSAGES:
djangojs.mo  djangojs.po  django.mo  django.po

credentials/conf/locale/fr_CA:
LC_MESSAGES

credentials/conf/locale/fr_CA/LC_MESSAGES:
djangojs.mo  djangojs.po  django.mo  django.po

```

 - [x] Test translations locally in devstack
<kbd>![image](https://github.com/openedx/credentials/assets/645156/d119a00b-74cc-442e-90c0-44718f240299)</kbd>


**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [ ] All tests pass

```sh
# Replicate `make test-karma`
$ make dev.shell.credentials
# Inside the shell
$ apt update -y
$ apt install --no-install-recommends -y firefox xvfb
$ xvfb-run ./node_modules/.bin/karma start
```

Tests doesn't work with the `credentials/Dockefile` repo, so I'm assuming this is something specific to the [`configuration`-based](https://github.com/openedx/configuration/blob/473a9faa3490fd7a9589e7a48e9e5423010fc69a/docker/build/credentials/Dockerfile) Dockerfile build.


References
----------

This contribution is part of the [FC-0012 project](https://openedx.atlassian.net/l/cp/XGS0iCcQ) which is sparked by the [Translation Infrastructure update OEP-58](https://open-edx-proposals.readthedocs.io/en/latest/architectural-decisions/oep-0058-arch-translations-management.html#specification).

Up-to-date project overview and details are available in the [Approach Memo and Technical Discovery: Translations Infrastructure Implementation](https://docs.google.com/document/d/11dFBCnbdHiCEdZp3pZeHdeH8m7Glla-XbIin7cnIOzU/edit#) document.

Join the conversation on [Open edX Slack #translations-project-fc-0012](https://openedx.slack.com/archives/C04R6TUJB7T).

Check the links above for full information about the overall project.

Internalization is being rearchitected in Open edX Python, XBlock, Micro-frontend, and other projects. There are a number of immediately visible changes:
 - Remove source and language translations from the repositories, hence no `.json`, `.po` or `.mo` files will be committed into the repos.
 - Add standardized `make extract_translations` in all repositories
 - Push user-facing messages strings into [openedx/openedx-translations](https://github.com/openedx/openedx-translations/).
 - Integrate root repositories with [openedx/openedx-atlas](https://github.com/openedx/openedx-atlas/) to pull translations on build/deploy time

Breaking Changes
----------------

One of the primary goals of the project is to **avoid breaking changes**. If you noticed any suspicious code, please raise your concern.