### PR TITLE
feat: adds a test for missing program cert record

### DIFF
--- a/credentials/apps/records/tests/test_utils.py
+++ b/credentials/apps/records/tests/test_utils.py
@@ -1,5 +1,5 @@
-from logging import INFO
 import urllib
+from logging import INFO
 
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
@@ -86,8 +86,9 @@ class UpdatedProgramEmailTests(SiteMixin, TestCase):
         # remover the fixture ProgramCertRecord
         ProgramCertRecord.objects.get(program=self.program, user=self.user).delete()
 
-        with self.assertLogs(level=INFO):
+        with self.assertLogs(level=INFO) as cm:
             send_updated_emails_for_program(self.request, self.USERNAME, self.pc)
+        self.assertRegex(cm.output[0], r".*ProgramCertRecord for user_uuid .*, program_uuid .* does not exist")
 
         # Check no other email was sent
         self.assertEqual(0, len(mail.outbox))

--- a/credentials/apps/records/tests/test_utils.py
+++ b/credentials/apps/records/tests/test_utils.py
@@ -1,5 +1,5 @@
 import urllib
-from logging import INFO
+from logging import DEBUG
 
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
@@ -86,7 +86,7 @@ class UpdatedProgramEmailTests(SiteMixin, TestCase):
         # remover the fixture ProgramCertRecord
         ProgramCertRecord.objects.get(program=self.program, user=self.user).delete()
 
-        with self.assertLogs(level=INFO) as cm:
+        with self.assertLogs(level=DEBUG) as cm:
             send_updated_emails_for_program(self.request, self.USERNAME, self.pc)
         self.assertRegex(cm.output[0], r".*ProgramCertRecord for user_uuid .*, program_uuid .* does not exist")
 

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -43,7 +43,7 @@ def send_updated_emails_for_program(request, username, program_certificate):
     try:
         pcr = ProgramCertRecord.objects.get(program=program, user=user)
     except ProgramCertRecord.DoesNotExist:
-        logger.info("Program Cert Record for user_uuid %s, program_uuid %s does not exist", user.id, program.uuid)
+        logger.info("ProgramCertRecord for user_uuid %s, program_uuid %s does not exist", user.id, program.uuid)
         return
 
     # Send emails for those already marked as "SENT"

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -43,7 +43,7 @@ def send_updated_emails_for_program(request, username, program_certificate):
     try:
         pcr = ProgramCertRecord.objects.get(program=program, user=user)
     except ProgramCertRecord.DoesNotExist:
-        logger.exception("Program Cert Record for user_uuid %s, program_uuid %s does not exist", user.id, program.uuid)
+        logger.info("Program Cert Record for user_uuid %s, program_uuid %s does not exist", user.id, program.uuid)
         return
 
     # Send emails for those already marked as "SENT"

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -43,7 +43,7 @@ def send_updated_emails_for_program(request, username, program_certificate):
     try:
         pcr = ProgramCertRecord.objects.get(program=program, user=user)
     except ProgramCertRecord.DoesNotExist:
-        logger.info("ProgramCertRecord for user_uuid %s, program_uuid %s does not exist", user.id, program.uuid)
+        logger.debug("ProgramCertRecord for user_uuid %s, program_uuid %s does not exist", user.id, program.uuid)
         return
 
     # Send emails for those already marked as "SENT"


### PR DESCRIPTION
* switch away from logger.exception (which was logging the noisy stacktrace as well as the log message) to logger.debug (because this is expected behavior and we don't want to see messages about it under normal conditions)
* Adding a test to verify

FIXES: APER-718

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
