### PR TITLE
build: migrate devstack cache backend

### DIFF
--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -16,7 +16,7 @@ LANGUAGE_CODE = os.environ.get("LANGUAGE_CODE", "en")
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.memcached.MemcachedCache",
+        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": os.environ.get("CACHE_LOCATION", "edx.devstack.memcached:11211"),
     }
 }

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -18,6 +18,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": os.environ.get("CACHE_LOCATION", "edx.devstack.memcached:11211"),
+        "OPTIONS": {"no_delay": True, "ignore_exec": True, "use_pooling": True},
     }
 }
 


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/openedx/credentials/issues/2144 to migrate credentials devstack cache backend from `MemcachedCache` to `PyMemcacheCache`