### PR TITLE
chore: pin `social-auth-app-django` to 5.2.x

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -692,8 +692,9 @@ slumber==0.7.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-rest-api-client
-social-auth-app-django==5.3.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-auth-backends

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -285,8 +285,9 @@ six==1.16.0
     #   python-memcached
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.3.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -38,3 +38,6 @@ django-simple-history<=3.1.1
 # The latest release of the edx-i18n-tools library seems appears to have a weird validation bug. Locking to the 0.9.x
 # release for now.
 edx-i18n-tools<1.0.0
+
+# The latest version of `social-auth-app-django` includes a large migration that is causing OOM issues
+social-auth-app-django<5.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -530,8 +530,9 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-social-auth-app-django==5.3.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -391,8 +391,9 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.3.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -458,8 +458,9 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.3.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.4.2


### PR DESCRIPTION
[APER-2847]

The latest version (5.3.0) of `social-auth-app-django` introduces a few migrations that can cause out-of-memory problems if the Credentials `social_auth_usersocialauth` table is large.

For now, we are pinning this package to an earlier version before the problematic migrations are introduced (5.2.0).

For more info, see: https://github.com/python-social-auth/social-app-django/issues/501

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
