### PR TITLE
fix: unpin social auth

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -692,9 +692,8 @@ slumber==0.7.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-auth-backends

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -285,9 +285,8 @@ six==1.16.0
     #   python-memcached
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -38,6 +38,3 @@ django-simple-history<=3.1.1
 # The latest release of the edx-i18n-tools library seems appears to have a weird validation bug. Locking to the 0.9.x
 # release for now.
 edx-i18n-tools<1.0.0
-
-# The latest version of `social-auth-app-django` includes a large migration that is causing OOM issues
-social-auth-app-django<5.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -530,9 +530,8 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -391,9 +391,8 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -458,9 +458,8 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.4.2


### PR DESCRIPTION
Temporarily unpinning `social-auth-app-django` so we can attempt to reverse the migration adding the `extra_data_new` column.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
