### PR TITLE
fix: fix keyword arg name in cache options

### DIFF
--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -18,7 +18,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": os.environ.get("CACHE_LOCATION", "edx.devstack.memcached:11211"),
-        "OPTIONS": {"no_delay": True, "ignore_exec": True, "use_pooling": True},
+        "OPTIONS": {"no_delay": True, "ignore_exc": True, "use_pooling": True},
     }
 }
 


### PR DESCRIPTION
This PR fixes the name of a keyword argument set in the `OPTIONS` dictionary for the cache configuration in the devstack settings.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
