### PR TITLE
feat: make catalog model fields read only in Django Admin

### DIFF
--- a/credentials/apps/catalog/admin.py
+++ b/credentials/apps/catalog/admin.py
@@ -7,14 +7,14 @@ from credentials.apps.catalog.models import Course, CourseRun, Organization, Pat
 class CourseAdmin(admin.ModelAdmin):
     list_display = ("id", "key", "uuid", "title")
     list_filter = ("site",)
-    readonly_fields = ("uuid",)
+    readonly_fields = ("id", "key", "uuid", "title", "owners", "site")
     search_fields = ("id", "key", "title", "uuid")
 
 
 @admin.register(CourseRun)
 class CourseRunAdmin(admin.ModelAdmin):
     list_display = ("id", "key", "uuid", "title_override", "start_date", "end_date")
-    readonly_fields = ("uuid",)
+    readonly_fields = ("id", "key", "uuid", "title_override", "start_date", "end_date", "course")
     search_fields = ("id", "key", "title_override", "uuid", "course__title")
 
 
@@ -22,7 +22,10 @@ class CourseRunAdmin(admin.ModelAdmin):
 class ProgramAdmin(admin.ModelAdmin):
     list_display = ("title", "uuid", "type")
     list_filter = ("site",)
-    readonly_fields = ("uuid",)
+    readonly_fields = (
+        "title", "uuid", "type", "course_runs", "site", "course_runs", "authoring_organizations", "type_slug",
+        "total_hours_of_effort", "status"
+    )
     search_fields = ("title", "uuid")
 
 
@@ -30,7 +33,7 @@ class ProgramAdmin(admin.ModelAdmin):
 class PathwayAdmin(admin.ModelAdmin):
     list_display = ("name", "org_name", "pathway_type", "email", "uuid")
     list_filter = ("site",)
-    readonly_fields = ("uuid",)
+    readonly_fields = ("name", "org_name", "pathway_type", "email", "uuid", "site", "programs")
     search_fields = ("name", "uuid")
 
 
@@ -38,5 +41,5 @@ class PathwayAdmin(admin.ModelAdmin):
 class OrganizationAdmin(admin.ModelAdmin):
     list_display = ("name", "key", "uuid")
     list_filter = ("site",)
-    readonly_fields = ("uuid",)
+    readonly_fields = ("name", "key", "uuid", "site", "certificate_logo_image_url")
     search_fields = ("name", "key", "uuid")

--- a/credentials/apps/catalog/admin.py
+++ b/credentials/apps/catalog/admin.py
@@ -23,8 +23,16 @@ class ProgramAdmin(admin.ModelAdmin):
     list_display = ("title", "uuid", "type")
     list_filter = ("site",)
     readonly_fields = (
-        "title", "uuid", "type", "course_runs", "site", "course_runs", "authoring_organizations", "type_slug",
-        "total_hours_of_effort", "status"
+        "title",
+        "uuid",
+        "type",
+        "course_runs",
+        "site",
+        "course_runs",
+        "authoring_organizations",
+        "type_slug",
+        "total_hours_of_effort",
+        "status",
     )
     search_fields = ("title", "uuid")
 


### PR DESCRIPTION
[APER-2841](https://2u-internal.atlassian.net/browse/APER-2841)

This PR updates the Catalog app's models available via Django Admin of the Credentials IDA to be read-only. We are making this change becuase Credentials is not the source of truth for this data, it is synced from the Course-Discovery IDA.

If the data needs to be updated, it should be done in Discovery and then admins should use the `copy-catalog` management command to sync the data to Credentials.

This is being done to ensure data integrity across services.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
