### PR TITLE
fix: remove duplicated field displayed in django admin for programs

### DIFF
--- a/credentials/apps/catalog/admin.py
+++ b/credentials/apps/catalog/admin.py
@@ -28,7 +28,6 @@ class ProgramAdmin(admin.ModelAdmin):
         "type",
         "course_runs",
         "site",
-        "course_runs",
         "authoring_organizations",
         "type_slug",
         "total_hours_of_effort",


### PR DESCRIPTION
This PR removes a field that was accidentally duplicated when displaying program data via Django admin.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
