### PR TITLE
feat: enforce CourseCertificate course_run, course_id presence

### DIFF
--- a/credentials/apps/api/v2/filters.py
+++ b/credentials/apps/api/v2/filters.py
@@ -16,8 +16,8 @@ class ProgramRelatedFilter(django_filters.Filter):
         except ValidationError:
             return UserCredential.objects.none()
 
-        course_runs = [run.key for run in program.course_runs.all()] if program else []
-        return qs.filter(Q(program_credentials__program_uuid=value) | Q(course_credentials__course_id__in=course_runs))
+        course_runs = program.course_runs.all() if program else []
+        return qs.filter(Q(program_credentials__program_uuid=value) | Q(course_credentials__course_run__in=course_runs))
 
 
 class CredentialTypeFilter(django_filters.Filter):

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -78,8 +78,8 @@ class CredentialField(serializers.Field):
             raise ValidationError({"course_run_key": msg})
         else:
             msg = (
-                "CourseCertificate failed to create because the CourseRun %s doesn't exist in the catalog",
-                course_run_key,
+                "CourseCertificate failed to create because the CourseRun %s doesn't exist in the catalog"
+                % course_run_key
             )
             raise ValidationError({"course_run_key": msg})
 

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -2,12 +2,14 @@
 Serializers for data manipulated by the credentials service APIs.
 """
 import logging
+from typing import TYPE_CHECKING
 
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
+import credentials.apps.catalog.api
 from credentials.apps.api.accreditors import Accreditor
 from credentials.apps.catalog.models import CourseRun
 from credentials.apps.credentials.constants import UserCredentialStatus
@@ -21,13 +23,17 @@ from credentials.apps.credentials.models import (
 from credentials.apps.records.models import UserGrade
 
 
+if TYPE_CHECKING:
+    from credentials.apps.credentials.models import AbstractCertificate
+
+
 logger = logging.getLogger(__name__)
 
 
 class CredentialField(serializers.Field):
     """Field identifying the credential type and identifiers."""
 
-    def to_internal_value(self, data):
+    def to_internal_value(self, data) -> "AbstractCertificate":
         site = self.context["request"].site
 
         program_uuid = data.get("program_uuid")
@@ -36,27 +42,23 @@ class CredentialField(serializers.Field):
                 return ProgramCertificate.objects.get(program_uuid=program_uuid, is_active=True)
             except ObjectDoesNotExist:
                 msg = f"No active ProgramCertificate exists for program [{program_uuid}]"
-                logger.exception(msg)
+                logger.error(msg)
                 raise ValidationError({"program_uuid": msg})
 
         course_run_key = data.get("course_run_key")
-        if course_run_key:
+        if not course_run_key:
+            raise ValidationError("Credential identifier is missing.")
+
+        # If we get this far, we necessarily have a course_run_key
+        course_runs = credentials.apps.catalog.api.get_course_runs_by_course_run_keys([course_run_key])
+        if course_runs:
+            course_run = course_runs[0]
             if self.read_only:
                 try:
-                    cert = CourseCertificate.objects.get(course_id=course_run_key, site=site)
+                    cert = CourseCertificate.objects.get(course_run=course_run, site=site)
                 except ObjectDoesNotExist:
                     cert = None
             else:
-                try:
-                    course_run = CourseRun.objects.get(key=course_run_key)
-                except ObjectDoesNotExist:
-                    logger.exception(
-                        "Course run certificate failed to create "
-                        f"because the course run [{course_run_key}] doesn't exist in the catalog"
-                    )
-                    # TODO: course_run is still nullable while we validate the data. Re raise the exception once the
-                    # field is no longer nullable
-                    course_run = None
                 # Create course cert on the fly, but don't upgrade it to active if it's manually been turned off
                 cert, _ = CourseCertificate.objects.get_or_create(
                     course_id=course_run_key,
@@ -67,15 +69,19 @@ class CredentialField(serializers.Field):
                         "certificate_type": data.get("mode"),
                     },
                 )
-
             if cert is None or not cert.is_active:
-                msg = f"No active CourseCertificate exists for course run [{course_run_key}]"
-                logger.exception(msg)
+                msg = "No active CourseCertificate exists for course run [%s]" % (course_run_key)
                 raise ValidationError({"course_run_key": msg})
-
             return cert
-
-        raise ValidationError("Credential identifier is missing.")
+        elif self.read_only:
+            msg = "No active CourseCertificate exists for course run [%s]" % (course_run_key)
+            raise ValidationError({"course_run_key": msg})
+        else:
+            msg = (
+                "CourseCertificate failed to create because the CourseRun %s doesn't exist in the catalog",
+                course_run_key,
+            )
+            raise ValidationError({"course_run_key": msg})
 
     def to_representation(self, value):
         """Serialize objects to a according to model content-type."""
@@ -88,7 +94,7 @@ class CredentialField(serializers.Field):
         else:  # course run
             credential = {
                 "type": "course-run",
-                "course_run_key": value.course_id,
+                "course_run_key": value.course_run.key,
                 "mode": value.certificate_type,
             }
 
@@ -115,10 +121,11 @@ class CourseRunField(serializers.Field):
     def to_internal_value(self, data):
         site = self.context["request"].site
         try:
+            # TODO use the catalog API, not direct reference
             return CourseRun.objects.get(key=data, course__site=site)
         except ObjectDoesNotExist:
             msg = f"No CourseRun exists for key [{data}]"
-            logger.exception(msg)
+            logger.error(msg)
             raise ValidationError(msg)
 
     def to_representation(self, value):
@@ -315,6 +322,7 @@ class CourseCertificateSerializer(serializers.ModelSerializer):
         course_id = validated_data["course_id"]
         course_run = None
         try:
+            # TODO use the catalog API, not direct reference
             course_run = CourseRun.objects.get(key=course_id)
         except ObjectDoesNotExist:
             logger.warning(

--- a/credentials/apps/api/v2/serializers.py
+++ b/credentials/apps/api/v2/serializers.py
@@ -70,16 +70,16 @@ class CredentialField(serializers.Field):
                     },
                 )
             if cert is None or not cert.is_active:
-                msg = "No active CourseCertificate exists for course run [%s]" % (course_run_key)
+                msg = f"No active CourseCertificate exists for course run [{course_run_key}]"
                 raise ValidationError({"course_run_key": msg})
             return cert
         elif self.read_only:
-            msg = "No active CourseCertificate exists for course run [%s]" % (course_run_key)
+            msg = f"No active CourseCertificate exists for course run [{course_run_key}]"
             raise ValidationError({"course_run_key": msg})
         else:
             msg = (
-                "CourseCertificate failed to create because the CourseRun %s doesn't exist in the catalog"
-                % course_run_key
+                f"CourseCertificate failed to create because the CourseRun {course_run_key} doesn't exist "
+                "in the catalog"
             )
             raise ValidationError({"course_run_key": msg})
 

--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -338,7 +338,8 @@ class CredentialViewSetTests(SiteMixin, APITestCase):
     def test_list_type_filtering(self):
         """Verify the endpoint returns data for all UserCredentials for the given type."""
         program_certificate = ProgramCertificateFactory(site=self.site)
-        course_certificate = CourseCertificateFactory(site=self.site)
+        course_run = CourseRunFactory()
+        course_certificate = CourseCertificateFactory(course_id=course_run.key, course_run=course_run, site=self.site)
 
         course_cred = UserCredentialFactory(credential=course_certificate)
         program_cred = UserCredentialFactory(credential=program_certificate)
@@ -358,7 +359,8 @@ class CredentialViewSetTests(SiteMixin, APITestCase):
     def test_list_visible_filtering(self):
         """Verify the endpoint can filter by visible date."""
         program_certificate = ProgramCertificateFactory(site=self.site)
-        course_certificate = CourseCertificateFactory(site=self.site)
+        course_run = CourseRunFactory()
+        course_certificate = CourseCertificateFactory(course_id=course_run.key, course_run=course_run, site=self.site)
 
         course_cred = UserCredentialFactory(credential=course_certificate)
         program_cred = UserCredentialFactory(credential=program_certificate)

--- a/credentials/apps/catalog/tests/test_api.py
+++ b/credentials/apps/catalog/tests/test_api.py
@@ -1,4 +1,5 @@
 import uuid
+from typing import TYPE_CHECKING, List
 
 from django.test import TestCase
 
@@ -17,6 +18,10 @@ from credentials.apps.catalog.tests.factories import (
 )
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory
+
+
+if TYPE_CHECKING:
+    from credentials.apps.credentials.models import CourseCertificate
 
 
 class APITests(TestCase):
@@ -44,7 +49,7 @@ class GetCourseRunsByCourseRunKeysTests(SiteMixin, TestCase):
         super().setUp()
         self.course = CourseFactory.create(site=self.site)
         self.course_runs = CourseRunFactory.create_batch(2, course=self.course)
-        self.course_certs = [
+        self.course_certs: List["CourseCertificate"] = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
                 site=self.site,
@@ -58,12 +63,12 @@ class GetCourseRunsByCourseRunKeysTests(SiteMixin, TestCase):
         assert len(result) == 0
 
     def test_get_course_runs_by_course_run_keys_one(self):
-        course_run_key = [self.course_certs[0].course_id]
+        course_run_key = [self.course_certs[0].course_run.key]
         result = get_course_runs_by_course_run_keys(course_run_key)
         assert result[0] == self.course_runs[0]
 
     def test_get_course_runs_by_course_run_keys_multiple(self):
-        course_run_keys = [course_cert.course_id for course_cert in self.course_certs]
+        course_run_keys = [course_cert.course_run.key for course_cert in self.course_certs]
         result = get_course_runs_by_course_run_keys(course_run_keys)
         assert result[0] == self.course_runs[0]
         assert result[1] == self.course_runs[1]

--- a/credentials/apps/credentials/api.py
+++ b/credentials/apps/credentials/api.py
@@ -2,6 +2,7 @@
 Python API utility functions exposed by the `credentials` Django app.
 """
 import logging
+from typing import TYPE_CHECKING, Optional
 
 from django.contrib.contenttypes.models import ContentType
 
@@ -13,6 +14,12 @@ from credentials.apps.credentials.models import (
     UserCredential as _UserCredential,
 )
 from credentials.apps.credentials.utils import filter_visible, get_credential_visible_date, get_credential_visible_dates
+
+
+if TYPE_CHECKING:
+    from django.contrib.sites.models import Site
+
+    from credentials.apps.catalog.models import CourseRun
 
 
 logger = logging.getLogger(__name__)
@@ -77,7 +84,7 @@ def _update_or_create_credential(username, credential_type, credential_id, statu
         return credential, created
 
 
-def get_course_cert_config(course_run, mode, create=False):
+def get_course_cert_config(course_run: "CourseRun", mode: str, create: bool = False) -> Optional[_CourseCertificate]:
     """
     A utility function that attempts to retrieve a course certificate configuration from the provided course run
     instance. Optionally attempts to create a course certificate configuration if one does not exist.
@@ -103,7 +110,7 @@ def get_course_cert_config(course_run, mode, create=False):
     return course_cert_config
 
 
-def create_course_cert_config(course_run, site, mode):
+def create_course_cert_config(course_run: "CourseRun", site: "Site", mode: str):
     """
     A utility function that attempts to create a CourseCertificate instance from the provided data.
 

--- a/credentials/apps/credentials/management/commands/populate_missing_courserun_info.py
+++ b/credentials/apps/credentials/management/commands/populate_missing_courserun_info.py
@@ -6,7 +6,6 @@ course_run table.
 import logging
 from typing import TYPE_CHECKING
 
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.core.management.base import BaseCommand
 
 from credentials.apps.catalog.api import get_course_runs_by_course_run_keys

--- a/credentials/apps/credentials/management/commands/tests/test_populate_missing_courserun_info.py
+++ b/credentials/apps/credentials/management/commands/tests/test_populate_missing_courserun_info.py
@@ -4,6 +4,7 @@ Tests for the populate_missing_courserun_info management command
 
 from logging import INFO, WARNING
 
+import pytest
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management import call_command
 from django.test import TestCase
@@ -26,6 +27,9 @@ class CourseCertificateCourseRunSyncTests(TestCase):
         self.course_run = CourseRunFactory()
         self.course_certificate = CourseCertificateFactory(course_id=self.course_run.key)
 
+    @pytest.mark.skip(
+        "It's now impossible to create a test object in this broken state, so no longer usefully testable"
+    )
     def test_update_ids(self):
         """verify ids were updated"""
         with self.assertRaises(ObjectDoesNotExist):
@@ -46,6 +50,9 @@ class CourseCertificateCourseRunSyncTests(TestCase):
         # verify no changes were made
         self.assertIsNone(course_certificate.course_run)
 
+    @pytest.mark.skip(
+        "It's now impossible to create a test object in this broken state, so no longer usefully testable"
+    )
     def test_dry_run(self):
         """verify course_ids were NOT updated"""
         with self.assertRaises(ObjectDoesNotExist):

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -198,7 +198,7 @@ class CourseCertificate(AbstractCertificate):
     .. no_pii: This model has no PII.
     """
 
-    # course_id is identical to course_run.key. It is a deprecated legacy property.  # For now it is still used as a
+    # course_id is identical to course_run.key. It is a deprecated legacy property.  For now it is still used as a
     # convenience accessor and filter but it will be eventually removed. If you need the value stored in course_id,
     # get it from course_run.key.
     course_id = models.CharField(max_length=255, validators=[validate_course_key])
@@ -237,7 +237,7 @@ class CourseCertificate(AbstractCertificate):
         return CourseKey.from_string(self.course_run.key)
 
     def save(self, *args, **kwargs):
-        """Force-create the course_run or sync course_id if missing.
+        """Force-create the course_run property or sync course_id if missing.
 
         The course_id can be wrong and need to be synced, because if created by CourseCertificate factory it gets
         a placeholder value.

--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -1,5 +1,6 @@
 import json
 from enum import Enum
+from typing import TYPE_CHECKING
 from unittest import mock
 
 import ddt
@@ -12,6 +13,10 @@ from credentials.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.tests.factories import CourseCertificateFactory, UserCredentialFactory
 from credentials.apps.records.tests.factories import UserGradeFactory
+
+
+if TYPE_CHECKING:
+    from credentials.apps.credentials.models import CourseCertificate, CourseRun
 
 
 JSON_CONTENT_TYPE = "application/json"
@@ -65,9 +70,9 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
         """
         Create the payload for a request and also the expected response.
         """
-        course_run = CourseRunFactory.create()
-        credential = CourseCertificateFactory.create(
-            course_id=course_run.course.id, site=self.site, course_run=course_run
+        course_run: "CourseRun" = CourseRunFactory.create()
+        credential: "CourseCertificate" = CourseCertificateFactory.create(
+            course_id=course_run.course.key, site=self.site, course_run=course_run
         )
         user_credential = UserCredentialFactory(
             credential=credential, credential__site=self.site, username=self.user.username

--- a/credentials/apps/credentials/tests/factories.py
+++ b/credentials/apps/credentials/tests/factories.py
@@ -1,11 +1,16 @@
 import datetime
 import uuid
+from typing import TYPE_CHECKING, Optional
 
 import factory
 
 from credentials.apps.catalog.tests.factories import ProgramFactory
 from credentials.apps.core.tests.factories import SiteFactory
 from credentials.apps.credentials import constants, models
+
+
+if TYPE_CHECKING:
+    from credentials.apps.credentials.models import CourseRun
 
 
 PASSWORD = "dummy-password"
@@ -19,11 +24,11 @@ class CourseCertificateFactory(AbstractCertificateFactory):
     class Meta:
         model = models.CourseCertificate
 
-    course_id = factory.Sequence(lambda o: "course-%d" % o)
     certificate_type = constants.CertificateType.HONOR
     is_active = True
     certificate_available_date = None
-    course_run = None
+    course_run: Optional["CourseRun"] = None
+    course_id = course_run.key if course_run else factory.Sequence(lambda o: "course-%d" % o)
 
 
 class ProgramCertificateFactory(AbstractCertificateFactory):

--- a/credentials/apps/credentials/tests/test_api.py
+++ b/credentials/apps/credentials/tests/test_api.py
@@ -43,6 +43,7 @@ class GetCourseCertificatesWithIdsTests(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs
@@ -278,7 +279,7 @@ class UpdateOrCreateCredentialTests(SiteMixin, TestCase):
         self.course = CourseFactory.create(site=self.site)
         self.course_run = CourseRunFactory.create(course=self.course)
         self.course_cert_config = CourseCertificateFactory.create(
-            course_id=self.course.id, course_run=self.course_run, site=self.site
+            course_id=self.course_run.key, course_run=self.course_run, site=self.site
         )
         self.program = ProgramFactory(
             title="TestProgram1", course_runs=[self.course_run], authoring_organizations=[self.org], site=self.site
@@ -463,7 +464,8 @@ class AwardCourseCertificateTests(SiteMixin, TestCase):
         assert credential.username == self.user.username
         assert credential.credential_id == course_cert_config.id
         assert credential.status == "awarded"
-        assert credential.credential_content_type_id == 12  # 12 is the content type for "Course Certificate"
+        # 12 is the content type for "Course Certificate"
+        assert credential.credential_content_type_id == 12
 
     def test_update_existing_cert(self):
         """
@@ -531,7 +533,8 @@ class AwardCourseCertificateTests(SiteMixin, TestCase):
         assert credential.username == self.user.username
         assert credential.credential_id == course_cert_config.id
         assert credential.status == "awarded"
-        assert credential.credential_content_type_id == 12  # 12 is the content type for "Course Certificate"
+        # 12 is the content type for "Course Certificate"
+        assert credential.credential_content_type_id == 12
 
     def test_award_course_cert_no_course_certificate_exception_occurs(self):
         """

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -147,7 +147,7 @@ def _get_program_certificate_visible_date(user_program_credential):
         # Does the user have a course cert for this course run?
         course_run_cert = UserCredential.objects.filter(
             username=user_program_credential.username,
-            course_credentials__course_id=course_run.key,
+            course_credentials__course_run=course_run,
         ).first()
 
         if course_run_cert:

--- a/credentials/apps/records/management/commands/seed-records.py
+++ b/credentials/apps/records/management/commands/seed-records.py
@@ -99,7 +99,11 @@ class Command(BaseCommand):
 
     @staticmethod
     def seed_courses(site, organizations, faker):
-        """Seed two courses per organization"""
+        """Seed two courses per organization
+
+        Unlike in the context of a UserCredential.course_id, course_id here does literally mean
+        the course.uuid, not course_run.key.
+        """
         courses = []
         course_id = 1
 
@@ -241,6 +245,7 @@ class Command(BaseCommand):
         for course_run in course_runs:
             course_certificate, created = CourseCertificate.objects.update_or_create(
                 site=site,
+                course_run=course_run,
                 course_id=course_run.key,
                 defaults={
                     "is_active": True,

--- a/credentials/apps/records/tests/test_utils.py
+++ b/credentials/apps/records/tests/test_utils.py
@@ -118,6 +118,7 @@ class CourseCredentialsToCourseRunsTests(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs
@@ -157,6 +158,7 @@ class CourseCredentialsToCourseRunsTests(SiteMixin, TestCase):
         self.course_certs2 = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs2
@@ -177,6 +179,7 @@ class CourseCredentialsToCourseRunsTests(SiteMixin, TestCase):
         self.course_certs2 = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs2
@@ -213,6 +216,7 @@ class GetCredentialsTests(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs
@@ -253,10 +257,10 @@ class GetCredentialsTests(SiteMixin, TestCase):
         assert program_results == []
 
     def test_get_credentials_program_only(self):
-        for course_run in self.course_runs:
-            course_run.delete()
         for course_cert in self.course_certs:
             course_cert.delete()
+        for course_run in self.course_runs:
+            course_run.delete()
         course_results, program_results = get_credentials(self.user.username)
         assert course_results == []
         assert program_results[0] == self.program_user_credential
@@ -280,6 +284,7 @@ class GetProgramDataTests(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -310,7 +310,12 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
             percent_grade=0.80,
         )
         self.course_certs = [
-            CourseCertificateFactory(course_id=course_run.key, site=self.site) for course_run in self.course_runs
+            CourseCertificateFactory(
+                course_run=course_run,
+                course_id=course_run.key,
+                site=self.site,
+            )
+            for course_run in self.course_runs
         ]
         self.credential_content_type = ContentType.objects.get(app_label="credentials", model="coursecertificate")
         self.user_credentials = [

--- a/credentials/apps/verifiable_credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/verifiable_credentials/rest_api/v1/tests/test_views.py
@@ -41,6 +41,7 @@ class ProgramCredentialsViewTests(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs
@@ -105,6 +106,7 @@ class InitIssuanceViewTestCase(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs

--- a/credentials/apps/verifiable_credentials/tests/test_utils.py
+++ b/credentials/apps/verifiable_credentials/tests/test_utils.py
@@ -40,6 +40,7 @@ class GetProgramCertificatesTests(SiteMixin, TestCase):
         self.course_certs = [
             CourseCertificateFactory.create(
                 course_id=course_run.key,
+                course_run=course_run,
                 site=self.site,
             )
             for course_run in self.course_runs


### PR DESCRIPTION
Will require thorough manual QA.

* on CourseCertificate save:
    * create course_run from course ID if needed
    * create course ID from course_run if needed
* refactored the CredentialField serializer to be more efficient given the change
* In most cases of direct object reference, switched from course_id to course_run.key
* Fixed a couple of bad tests that confused thought course_id should reference course_run.course.id (alas for legacy name issues)
* Cleaned up a few log messages (log levels, text, clarity, string formatting)
* marked some tests as skip
    * Given the enforced save method, making objects broken enough to prove the test cases would require mocking so extreme as to make the tests practically useless
    * The enforced data validation is tested elsewhere, by the rest of the test suite

Additionally:

* Added type checking, not ubiquitously, but wherever it helped me debug
* Added a few explanatory comments where it helped me debug
* let black reformat a couple of files that I touched but otherwise didn't change

Tickets to be created for future work:

* Make course_run non-nullable
    * data migration to fix missing course_run for anyone who hasn't run populate_missing_courserun_info
    * schema migration
    * raise helpful error on illegal creation
* (Optional) completely strip out course_id
    * this one may not be worth it; as long as the fields are forced to be identical and present, it's fine to have a convenience property

FIXES: APER-1136

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
