### PR TITLE
feat!: Django 4.0 and above, CSRF_TRUSTED_ORIGINS must include schemes

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -558,3 +558,5 @@ EVENT_BUS_REDIS_CONNECTION_URL = "redis://:password@edx.devstack.redis:6379/"
 EVENT_BUS_TOPIC_PREFIX = "dev"
 
 PROGRAM_CERTIFICATE_EVENTS_KAFKA_TOPIC_NAME = "learning-program-certificate-lifecycle"
+
+CSRF_TRUSTED_ORIGINS_WITH_SCHEME = [] # just for Django 4.2 upgrade

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -559,4 +559,4 @@ EVENT_BUS_TOPIC_PREFIX = "dev"
 
 PROGRAM_CERTIFICATE_EVENTS_KAFKA_TOPIC_NAME = "learning-program-certificate-lifecycle"
 
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = [] # just for Django 4.2 upgrade
+CSRF_TRUSTED_ORIGINS_WITH_SCHEME = []  # just for Django 4.2 upgrade

--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -1,5 +1,6 @@
 from os import environ
 
+import django
 import yaml
 
 from edx_django_utils.plugins import add_plugins
@@ -62,3 +63,6 @@ for override, value in DB_OVERRIDES.items():
     DATABASES["default"][override] = value
 
 add_plugins(__name__, PROJECT_TYPE, SettingsType.PRODUCTION)
+
+if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
+    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
Adding condition to load schemes as per django-version.

Related PR for https://github.com/edx/edx-internal/pull/9315/files