### PR TITLE
chore: using `CSRF_TRUSTED_ORIGINS` now. No need for extra variable.

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -559,5 +559,3 @@ EVENT_BUS_REDIS_CONNECTION_URL = "redis://:password@edx.devstack.redis:6379/"
 EVENT_BUS_TOPIC_PREFIX = "dev"
 
 PROGRAM_CERTIFICATE_EVENTS_KAFKA_TOPIC_NAME = "learning-program-certificate-lifecycle"
-
-CSRF_TRUSTED_ORIGINS_WITH_SCHEME = []  # just for Django 4.2 upgrade

--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -1,6 +1,5 @@
 from os import environ
 
-import django
 import yaml
 
 from edx_django_utils.plugins import add_plugins
@@ -63,6 +62,3 @@ for override, value in DB_OVERRIDES.items():
     DATABASES["default"][override] = value
 
 add_plugins(__name__, PROJECT_TYPE, SettingsType.PRODUCTION)
-
-if django.VERSION[0] >= 4:  # for greater than django 3.2 use schemes.
-    CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS_WITH_SCHEME


### PR DESCRIPTION
Merge this PR first https://github.com/edx/edx-internal/pull/9413/files. 
So that configs got available on argocd.

For Quince this cleanup require.