### PR TITLE
refactor: update application code to use `get_user_by_username` utility function

### DIFF
--- a/credentials/apps/credentials/rest_api/v1/views.py
+++ b/credentials/apps/credentials/rest_api/v1/views.py
@@ -10,6 +10,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from credentials.apps.core.api import get_user_by_username
 from credentials.apps.credentials.rest_api.v1.permissions import CanGetLearnerStatus
 from credentials.apps.records.api import get_learner_course_run_status
 
@@ -118,8 +119,11 @@ class LearnerCertificateStatusView(APIView):
 
         try:
             if username:
-                user = User.objects.get(username=username)
-                lms_user_id = user.lms_user_id
+                user = get_user_by_username(username)
+                if user:
+                    lms_user_id = user.lms_user_id
+                else:
+                    raise User.DoesNotExist()
             else:
                 user = User.objects.get(lms_user_id=lms_user_id)
                 username = user.username

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -9,7 +9,7 @@ from django.db.models import Q
 from edx_ace import Recipient, ace
 
 from credentials.apps.catalog.data import ProgramStatus
-from credentials.apps.core.models import User
+from credentials.apps.core.api import get_user_by_username
 from credentials.apps.credentials.messages import ProgramCertificateIssuedMessage
 from credentials.apps.credentials.models import (
     ProgramCompletionEmailConfiguration,
@@ -256,8 +256,14 @@ def send_program_certificate_created_message(username, program_certificate, lms_
     """
     If the learner has earned a Program Certificate then we go ahead and send them an automated email congratulating
     them for their achievement. Emails to learners in credit eligible Programs will contain additional information.
+
+    Args:
+        username (string): The username of the user we will send the email to
+        program_certificate (AbstractCredential[ProgramCertificate]): A ProgramCertificate configuration for a program,
+         used to pull program details used in the program completion email
+        lms_user_id (int): The LMS User Id of the user we will send the email to
     """
-    user = User.objects.get(username=username)
+    user = get_user_by_username(username)
     program_uuid = program_certificate.program_uuid
     program_details = program_certificate.program_details
 

--- a/credentials/apps/records/management/commands/seed-records.py
+++ b/credentials/apps/records/management/commands/seed-records.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from faker import Faker
 
 from credentials.apps.catalog.models import Course, CourseRun, Organization, Pathway, Program
-from credentials.apps.core.models import User
+from credentials.apps.core.api import get_user_by_username
 from credentials.apps.credentials.constants import CertificateType
 from credentials.apps.credentials.models import CourseCertificate, ProgramCertificate, Signatory, UserCredential
 from credentials.apps.records.constants import UserCreditPathwayStatus
@@ -183,7 +183,7 @@ class Command(BaseCommand):
     @staticmethod
     def get_user(username):
         """Get the test user"""
-        return User.objects.get(username=username)
+        return get_user_by_username(username=username)
 
     @staticmethod
     def seed_user_grades(user, course_runs):

--- a/credentials/apps/records/utils.py
+++ b/credentials/apps/records/utils.py
@@ -10,7 +10,7 @@ from edx_ace import Recipient, ace
 from credentials.apps.catalog.api import get_filtered_programs
 from credentials.apps.catalog.data import ProgramStatus
 from credentials.apps.catalog.models import Program
-from credentials.apps.core.models import User
+from credentials.apps.core.api import get_user_by_username
 from credentials.apps.credentials.api import (
     get_course_certificates_with_ids,
     get_program_certificates_with_ids,
@@ -31,11 +31,19 @@ logger = logging.getLogger(__name__)
 
 
 def send_updated_emails_for_program(request, username, program_certificate):
-    """If the user has previously sent an email to a pathway org, we want to send
-    an updated one when they finish the program.  This function is called from the
-    credentials Program Certificate awarding API"""
+    """
+    If the user has previously sent an email to a pathway org, we want to send an updated one when they finish the
+    program.  This function is called from the credentials Program Certificate awarding API
+
+    Args:
+        request (HttpRequest): The HttpRequest object, used to extract information about the learner's achievement when
+         sending an updated Pathway email
+        username (string): The username of the user we will send on behalf of
+        program_certificate (AbstractCredential[ProgramCertificate]): A ProgramCertificate configuration for a program,
+         used to pull program details used in the updated Pathway program email
+    """
     site = program_certificate.site
-    user = User.objects.get(username=username)
+    user = get_user_by_username(username)
     program_uuid = program_certificate.program_uuid
 
     program = Program.objects.prefetch_related("pathways").get(site=site, uuid=program_uuid)

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -20,6 +20,7 @@ from edx_ace import Recipient, ace
 from ratelimit.decorators import ratelimit
 
 from credentials.apps.catalog.models import Pathway, Program
+from credentials.apps.core.api import get_user_by_username
 from credentials.apps.core.views import ThemeViewMixin
 from credentials.apps.credentials.models import ProgramCertificate, UserCredential
 from credentials.apps.records.api import get_program_record_data
@@ -251,9 +252,9 @@ class ProgramRecordCreationView(LoginRequiredMixin, RecordsEnabledMixin, View):
         body = json.loads(body_unicode)
 
         username = body["username"]
-        try:
-            user = User.objects.get(username=username)
-        except User.DoesNotExist:
+
+        user = get_user_by_username(username)
+        if not user:
             return JsonResponse({"error": "User does not exist"}, status=404)
 
         # verify that the user or an admin is making the request


### PR DESCRIPTION
[APER-2873]

A cleanup PR that refactors code in Credentials to use the `get_user_by_username` utility function over importing and using the User model directly.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
