### PR TITLE
feat!: Remove unused feature flag

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -482,8 +482,9 @@ SOCIAL_AUTH_REDIRECT_IS_HTTPS = False
 # .. toggle_name: SEND_EMAIL_ON_PROGRAM_COMPLETION
 # .. toggle_implementation: SettingToggle
 # .. toggle_default: False
-# .. toggle_description: Toggle to control if we send a congratulatory email to learners after being issued a Program Certificate
-# .. toggle_use_cases: open_edx
+# .. toggle_description: If enabled (and configured), the system will send a congratulatory email to learners upon
+#    being awarded a program certificate.
+# .. toggle_use_cases: opt_in
 # .. toggle_creation_date: 2020-10-08
 # .. toggle_target_removal_date: NA
 # .. toggle_warning: This is a toggle for the feature
@@ -533,16 +534,7 @@ LOGO_WHITE_URL_SVG = "https://edx-cdn.org/v3/default/logo-white.svg"
 FAVICON_URL = "https://edx-cdn.org/v3/default/favicon.ico"
 LOGO_POWERED_BY_OPEN_EDX_URL = "https://edx-cdn.org/v3/prod/open-edx-tag.svg"
 
-# .. toggle_name: USE_LEARNER_RECORD_MFE
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: Determines if the Credentials IDA should redirect to the Learner Record MFE when navigating
-#   between the program detail page and program list pages.
-# .. toggle_warning: Requires the Learner Record MFE to be deployed in a given environment if toggled to true. Requires
-#   a value to be set for the `LEARNER_RECORD_MFE_RECORDS_PAGE_URL` for navigation to route properly.
-# .. toggle_use_cases: opt_in
-# .. toggle_creation_date: 2021-08-10
-USE_LEARNER_RECORD_MFE = False
+# Learner Record MFE Settings
 LEARNER_RECORD_MFE_RECORDS_PAGE_URL = ""
 
 # Plugin Django Apps

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -97,7 +97,6 @@ JWT_AUTH.update(
 
 SEND_EMAIL_ON_PROGRAM_COMPLETION = True
 
-USE_LEARNER_RECORD_MFE = False
 LEARNER_RECORD_MFE_RECORDS_PAGE_URL = "http://localhost:1990/"
 
 add_plugins(__name__, PROJECT_TYPE, SettingsType.DEVSTACK)

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -81,3 +81,5 @@ VERIFIABLE_CREDENTIALS = {
         "NAME": "test-issuer-name",
     }
 }
+
+LEARNER_RECORD_MFE_RECORDS_PAGE_URL = "http://learner-record-mfe"

--- a/docs/learner_records.rst
+++ b/docs/learner_records.rst
@@ -48,15 +48,6 @@ Enabling Program Records
 Program Record support is enabled by default. Optionally, an Administrator may disable support for the program record
 feature by disabling the ``Enable Learner Records`` checkbox in your site's ``Site Configuration`` (via Django Admin).
 
-To properly enable support for the Learner Record MFE from Credentials, the ``LEARNER_RECORD_MFE_RECORDS_PAGE_URL``
-setting must be set in configuration.
-
-::
-    The following is temporary and leftover from the original implementation of the Learner Record MFE. The Learner
-    Record MFE is a **required** component of the Credentials IDA and in the future its use will be enabled by default.
-
-Additionally, the ``USE_LEARNER_RECORD_MFE`` setting must be enabled.
-
 Creation
 --------
 


### PR DESCRIPTION
[APER-2913]

This PR removes the `USE_LEARNER_RECORD_MFE` feature flag. This was originally used to gate redirections to the Learner Record MFE when it was under development.

The Learner Record MFE is now required for program record functionality, the legacy FE was removed as part of #2104 and #2106.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
