### PR TITLE
fix: remove social-auth constraint

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,7 +30,3 @@ analytics-python<=1.4.0
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2
-
-
-# The latest version of `social-auth-app-django` includes a large migration that is causing OOM issues
-social-auth-app-django<5.3.0


### PR DESCRIPTION
[APER-2848]

The maintainers of `social-auth-app-django` have gone back and optimized the data migration and this _should_ (hopefully) resolve the problems we had upgrading to the latest version a few weeks back.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
