### PR TITLE
fix: pin `social-auth-app-django` to 5.2.0... again

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -46,11 +46,11 @@ bleach==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.28.69
+boto3==1.28.70
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.31.69
+botocore==1.31.70
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -340,7 +340,7 @@ filelock==3.12.4
     #   virtualenv
 gevent==23.9.1
     # via -r requirements/production.txt
-greenlet==3.0.0
+greenlet==3.0.1
     # via
     #   -r requirements/production.txt
     #   gevent
@@ -569,7 +569,7 @@ pyrsistent==0.19.3
     # via
     #   -r requirements/dev.txt
     #   jsonschema
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/dev.txt
     #   pytest-django
@@ -688,8 +688,9 @@ slumber==0.7.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-rest-api-client
-social-auth-app-django==5.4.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-auth-backends

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -283,8 +283,9 @@ six==1.16.0
     #   python-memcached
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.4.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,3 +30,7 @@ analytics-python<=1.4.0
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2
+
+# social-auth-app-django versions after 5.2.0 has a problematic migration that will cause issues deployments with large
+# `social_auth_usersocialauth` tables
+social-auth-app-django<5.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -427,7 +427,7 @@ pypng==0.20220715.0
     #   qrcode
 pyrsistent==0.19.3
     # via jsonschema
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/test.txt
     #   pytest-django
@@ -522,8 +522,9 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-social-auth-app-django==5.4.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -27,9 +27,9 @@ backports-zoneinfo==0.2.1
     #   django
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.28.69
+boto3==1.28.70
     # via django-ses
-botocore==1.31.69
+botocore==1.31.70
     # via
     #   boto3
     #   s3transfer
@@ -199,7 +199,7 @@ fastavro==1.8.4
     #   openedx-events
 gevent==23.9.1
     # via -r requirements/production.in
-greenlet==3.0.0
+greenlet==3.0.1
     # via gevent
 gunicorn==21.2.0
     # via -r requirements/production.in
@@ -395,8 +395,9 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.4.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -369,7 +369,7 @@ pypng==0.20220715.0
     # via
     #   -r requirements/base.txt
     #   qrcode
-pytest==7.4.2
+pytest==7.4.3
     # via
     #   -r requirements/test.in
     #   pytest-django
@@ -454,8 +454,9 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.4.0
+social-auth-app-django==5.2.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.4.2


### PR DESCRIPTION
**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
