### PR TITLE
feat: emit Segment event when creating or updating a program credential

### DIFF
--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -263,7 +263,7 @@ class UsernameReplacementView(APIView):
                     num_rows_changed += model.objects.filter(**{column: current_username}).update(
                         **{column: new_username}
                     )
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception as exc:
             log.exception(
                 "Unable to change username from %s to %s. Failed on table %s because %s",
                 current_username,

--- a/credentials/apps/core/api.py
+++ b/credentials/apps/core/api.py
@@ -49,7 +49,7 @@ def get_or_create_user_from_event_data(user_data):
         # create the user if they don't exist, this follows similar behavior that our JWT authentication implements if
         # a user doesn't exist when we're making network calls across services
         user, created = User.objects.get_or_create(username=user_data.pii.username)
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:
         logger.exception("Error occurred retrieving or creating a user")
         return None, None
 

--- a/credentials/apps/credentials/api.py
+++ b/credentials/apps/credentials/api.py
@@ -73,7 +73,7 @@ def _update_or_create_credential(username, credential_type, credential_id, statu
             credential_id=credential_id,
             defaults={"status": status},
         )
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:
         logger.exception(
             f"Error occurred processing a credential with credential_id [{credential_id}] for user [{username}]"
         )
@@ -131,7 +131,7 @@ def create_course_cert_config(course_run: "CourseRun", site: "Site", mode: str):
         course_cert_config = _CourseCertificate.objects.create(
             course_id=course_run.key, course_run=course_run, site=site, is_active=True, certificate_type=mode
         )
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:
         logger.exception(f"Error occurred creating a CourseCertificate configuration for course run [{course_run.key}]")
 
     return course_cert_config

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -286,8 +286,8 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
 
     def _emit_program_certificate_segment_event(self, request, site_config, user, user_credential, credential, created):
         """
-        A utility function used to dispatch a Segment event when a program certificate has been updated. This includes
-        upon initial creation or an update later (revocation, re-awarding).
+        A utility function used to dispatch a Segment event when a program certificate record has been created or
+        updated.
 
         Args:
             request (HttpRequest): The original request object from the credential update request
@@ -310,18 +310,11 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
             segment_client = SegmentClient(write_key=site_config.segment_key)
 
         if segment_client:
-            anonymous_id = None
-            if request and request.COOKIES:
-                anonymous_id = request.COOKIES.get("ajs_anonymous_id", str(uuid4()))
-            else:
-                anonymous_id = str(uuid4())
-
             event_name = "edx.bi.credentials.credential_issuers.program_certificate_updated"
             if created:
                 event_name = "edx.bi.credentials.credential_issuers.program_certificate_created"
 
             program = credential.program
-
             event_properties = {
                 "category": "credentials",
                 "user": {
@@ -340,7 +333,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
             }
 
             segment_client.track(
-                anonymous_id=anonymous_id,
+                anonymous_id=user.lms_user_id,
                 event=event_name,
                 properties=event_properties,
             )

--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -5,7 +5,6 @@ Issuer classes used to generate credentials for learners.
 import abc
 import logging
 from datetime import timezone
-from uuid import uuid4
 
 from analytics.client import Client as SegmentClient
 from django.conf import settings

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -384,6 +384,7 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         mock_segment_client_method_calls = mock_segment_client.method_calls
         assert len(mock_segment_client_method_calls) == 1
         call_args = mock_segment_client_method_calls[0].kwargs
+        assert call_args["anonymous_id"] == self.user.lms_user_id
         assert call_args["event"] == expected_event_name
         assert call_args["properties"] == expected_event_properties
 
@@ -425,6 +426,7 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         mock_segment_client_method_calls = mock_segment_client.method_calls
         assert len(mock_segment_client_method_calls) == 1
         call_args = mock_segment_client_method_calls[0].kwargs
+        assert call_args["anonymous_id"] == self.user.lms_user_id
         assert call_args["event"] == expected_event_name
         assert call_args["properties"] == expected_event_properties
 

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -20,7 +20,11 @@ from credentials.apps.credentials.models import (
     UserCredential,
     UserCredentialAttribute,
 )
-from credentials.apps.credentials.tests.factories import CourseCertificateFactory, ProgramCertificateFactory
+from credentials.apps.credentials.tests.factories import (
+    CourseCertificateFactory,
+    ProgramCertificateFactory,
+    UserCredentialFactory,
+)
 
 
 User = get_user_model()
@@ -40,40 +44,8 @@ class CertificateIssuerBase:
     def setUp(self):
         super().setUp()
         self.certificate = self.cert_factory.create()
-        self.username = "tester"
-        self.user = UserFactory(username=self.username)
-        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
+        self.user = UserFactory()
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
-
-    def test_issued_credential_type(self):
-        """
-        Verify issued_credential_type returns the correct credential type.
-        """
-        self.assertEqual(self.issuer.issued_credential_type, self.cert_type)
-
-    def test_issue_existing_credential(self):
-        """
-        Verify credentials can be updated when re-issued.
-        """
-        user_credential = self.issuer.issue_credential(self.certificate, self.username, "revoked")
-        self.user_cred.refresh_from_db()
-        self._assert_usercredential_fields(self.user_cred, self.certificate, self.username, "revoked", [])
-        self.assertEqual(user_credential, self.user_cred)
-
-    def test_issue_credential_without_attributes(self):
-        """
-        Verify credentials can be issued without attributes.
-        """
-        user_credential = self.issuer.issue_credential(self.certificate, self.username)
-        self._assert_usercredential_fields(user_credential, self.certificate, self.username, "awarded", [])
-
-    def test_issue_credential_with_attributes(self):
-        """
-        Verify credentials can be issued with attributes.
-        """
-        UserFactory(username="testuser2")
-        user_credential = self.issuer.issue_credential(self.certificate, "testuser2", attributes=self.attributes)
-        self._assert_usercredential_fields(user_credential, self.certificate, "testuser2", "awarded", self.attributes)
 
     def _assert_usercredential_fields(
         self, user_credential, expected_credential, expected_username, expected_status, expected_attrs
@@ -85,19 +57,53 @@ class CertificateIssuerBase:
         actual_attributes = [{"name": attr.name, "value": attr.value} for attr in user_credential.attributes.all()]
         self.assertEqual(actual_attributes, expected_attrs)
 
+    def test_issued_credential_type(self):
+        """
+        Verify issued_credential_type returns the correct credential type.
+        """
+        self.assertEqual(self.issuer.issued_credential_type, self.cert_type)
+
+    def test_issue_existing_credential(self):
+        """
+        Verify credentials can be updated when re-issued.
+        """
+        self.issuer.issue_credential(self.certificate, self.user.username, "awarded")
+        updated_credential = self.issuer.issue_credential(self.certificate, self.user.username, "revoked")
+        user_credential = UserCredential.objects.get(username=self.user.username, credential_id=self.certificate.id)
+        self._assert_usercredential_fields(user_credential, self.certificate, self.user.username, "revoked", [])
+        self.assertEqual(updated_credential, user_credential)
+
+    def test_issue_credential_without_attributes(self):
+        """
+        Verify credentials can be issued without attributes.
+        """
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username)
+        self._assert_usercredential_fields(user_credential, self.certificate, self.user.username, "awarded", [])
+
+    def test_issue_credential_with_attributes(self):
+        """
+        Verify credentials can be issued with attributes.
+        """
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username, attributes=self.attributes)
+        self._assert_usercredential_fields(
+            user_credential, self.certificate, self.user.username, "awarded", self.attributes
+        )
+
     def test_set_credential_without_attributes(self):
         """
         Verify that if no attributes given then None will return.
         """
-        self.assertEqual(self.issuer.set_credential_attributes(self.user_cred, None), None)
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username, "awarded")
+        self.assertEqual(self.issuer.set_credential_attributes(user_credential, None), None)
 
     def test_set_credential_with_attributes(self):
         """
         Verify that the system can associate credential attributes with a learner's credential.
         """
-        self.issuer.set_credential_attributes(self.user_cred, self.attributes)
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username, "awarded")
+        self.issuer.set_credential_attributes(user_credential, self.attributes)
         self._assert_usercredential_fields(
-            self.user_cred, self.certificate, self.user_cred.username, "awarded", self.attributes
+            user_credential, self.certificate, self.user.username, "awarded", self.attributes
         )
 
     def test_set_credential_with_duplicate_attributes_by_util(self):
@@ -105,26 +111,28 @@ class CertificateIssuerBase:
         Verify that the application throws an exception is thrown if it encounters a duplicate attribute related to a
         learner's credential.
         """
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username, "awarded")
         self.attributes.append({"name": "whitelist_reason", "value": "Reason for whitelisting."})
 
         with self.assertRaises(DuplicateAttributeError):
-            self.issuer.set_credential_attributes(self.user_cred, self.attributes)
+            self.issuer.set_credential_attributes(user_credential, self.attributes)
 
     def test_existing_credential_with_duplicate_attributes(self):
         """
         Verify if user credential attributes already exists in db then method will update existing attributes values.
         """
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username, "awarded")
+
         # add the attribute in db and then try to create the credential with same data "names but value is different"
         attribute_db = {"name": "whitelist_reason", "value": "Reason for whitelisting."}
-
         UserCredentialAttribute.objects.create(
-            user_credential=self.user_cred, name=attribute_db.get("name"), value=attribute_db.get("value")
+            user_credential=user_credential, name=attribute_db.get("name"), value=attribute_db.get("value")
         )
-        self.issuer.set_credential_attributes(self.user_cred, self.attributes)
+        self.issuer.set_credential_attributes(user_credential, self.attributes)
 
         # first attribute value will be changed to 0.5
         self._assert_usercredential_fields(
-            self.user_cred, self.certificate, self.user_cred.username, "awarded", self.attributes
+            user_credential, self.certificate, self.user.username, "awarded", self.attributes
         )
 
     def test_existing_attributes_with_empty_attributes_list(self):
@@ -132,16 +140,16 @@ class CertificateIssuerBase:
         Verify if user credential attributes already exists in db then in case of empty attributes list it will return
         without changing any data.
         """
-
-        self.issuer.set_credential_attributes(self.user_cred, self.attributes)
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username, "awarded")
+        self.issuer.set_credential_attributes(user_credential, self.attributes)
         self._assert_usercredential_fields(
-            self.user_cred, self.certificate, self.user_cred.username, "awarded", self.attributes
+            user_credential, self.certificate, self.user.username, "awarded", self.attributes
         )
 
         # create same credential without attributes.
-        self.assertIsNone(self.issuer.set_credential_attributes(self.user_cred, []))
+        self.assertIsNone(self.issuer.set_credential_attributes(user_credential, []))
         self._assert_usercredential_fields(
-            self.user_cred, self.certificate, self.user_cred.username, "awarded", self.attributes
+            user_credential, self.certificate, self.user.username, "awarded", self.attributes
         )
 
 
@@ -158,99 +166,95 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         super().setUp()
         self.site = SiteFactory()
         self.site_config = SiteConfigurationFactory(site=self.site)
+        self.site.siteconfiguration = self.site_config
         self.program = ProgramFactory(site=self.site, uuid=uuid4())
         self.certificate = self.cert_factory.create(
             program_uuid=self.program.uuid, program=self.program, site=self.site
         )
-        self.username = "tester2"
-        self.user = UserFactory(username=self.username)
-        self.user_cred = self.issuer.issue_credential(self.certificate, self.username)
+        self.user = UserFactory()
         self.attributes = [{"name": "whitelist_reason", "value": "Reason for whitelisting."}]
 
     def test_records_enabled_is_unchecked(self):
         """
-        Verify that if SiteConfiguration.records_enabled is unchecked then don't send updated email to a pathway org.
+        Verify that, when records are disabled for a site, if a new program credential is issued to a learner that we
+        do not attempt to send an updated email to a Pathway org.
         """
         self.site_config.records_enabled = False
         self.site_config.save()
 
         with mock.patch("credentials.apps.credentials.issuers.send_updated_emails_for_program") as mock_method:
-            self.issuer.issue_credential(self.certificate, "testuser3", attributes=self.attributes)
+            self.issuer.issue_credential(self.certificate, self.user.username, attributes=self.attributes)
             self.assertEqual(mock_method.call_count, 0)
 
     def test_records_enabled_is_checked(self):
         """
-        Verify that if SiteConfiguration.records_enabled is checked and new record is created then updated email is
-        sent to a pathway org.
+        Verify that, when records are enabled for a site, if a new program credential is issued to a learner that we
+        check to see if we need to send an updated email to a Pathway org.
         """
         with mock.patch("credentials.apps.credentials.issuers.send_updated_emails_for_program") as mock_method:
-            self.issuer.issue_credential(self.certificate, "testuser4", attributes=self.attributes)
+            self.issuer.issue_credential(self.certificate, self.user.username, attributes=self.attributes)
             self.assertEqual(mock_method.call_count, 1)
 
     @override_settings(SEND_EMAIL_ON_PROGRAM_COMPLETION=True)
     @mock.patch("credentials.apps.credentials.issuers.send_program_certificate_created_message")
-    def test_send_learner_email_when_issuing_program_cert(self, mock_send_learner_email):
+    def test_send_learner_email_when_awarding_program_cert(self, mock_send_learner_email):
         """
-        Verify that the application sends a program completion email when a learner is issued a credential for the first
-        time.
+        Verify that, when the program completion email feature is enabled, we call the proper utility function when
+        awarding a program credential to a learner for the first time.
         """
         self.site_config.records_enabled = False
         self.site_config.save()
 
-        self.issuer.issue_credential(self.certificate, "testuser5", lms_user_id=123)
+        self.issuer.issue_credential(self.certificate, self.user.username, lms_user_id=self.user.lms_user_id)
         self.assertEqual(mock_send_learner_email.call_count, 1)
 
     @override_settings(SEND_EMAIL_ON_PROGRAM_COMPLETION=True)
     @mock.patch("credentials.apps.credentials.issuers.send_program_certificate_created_message")
     def test_send_learner_email_only_once(self, mock_send_learner_email):
         """
-        Verify that the application will not send additional program completion emails if the certificate is modified
-        after originally being issued.
+        Verify that, when the program completion email feature is enabled, we do *not* attempt to send a program
+        completion email if we are re-awarding a program credential to a learner.
         """
-        username = "learner"
-        user = UserFactory(username=username)
-
         self.site_config.records_enabled = False
         self.site_config.save()
 
-        self.issuer.issue_credential(self.certificate, user.username, lms_user_id=123)
+        self.issuer.issue_credential(self.certificate, self.user.username, lms_user_id=self.user.lms_user_id)
         # revoke the user credential
-        user_credential = UserCredential.objects.get(username=username)
+        user_credential = UserCredential.objects.get(username=self.user.username)
         user_credential.revoke()
         # issue the credential again, make sure that we haven't tried to send the email again
-        self.issuer.issue_credential(self.certificate, user.username, lms_user_id=123)
+        self.issuer.issue_credential(self.certificate, self.user.username, lms_user_id=self.user.lms_user_id)
         self.assertEqual(mock_send_learner_email.call_count, 1)
 
     @override_settings(SEND_EMAIL_ON_PROGRAM_COMPLETION=False)
     @mock.patch("credentials.apps.credentials.issuers.send_program_certificate_created_message")
     def test_do_not_send_learner_email_when_feature_disabled(self, mock_send_learner_email):
         """
-        Verify that we don't try to send an updated program progress email when issuing an updated program credential.
+        Verify that, when the program completion email feature is disabled, we do *not* attempt to send a program
+        completion email when awarding a program credential to a learner for the first time.
         """
         self.site_config.records_enabled = False
         self.site_config.save()
 
-        self.issuer.issue_credential(self.certificate, "testuser6")
+        self.issuer.issue_credential(self.certificate, self.user.username)
         self.assertEqual(mock_send_learner_email.call_count, 0)
 
     @mock.patch("credentials.apps.credentials.issuers.ProgramCertificateIssuer._emit_program_certificate_signal")
     def test_publish_program_certificate_signal(self, mock_emit):
         """
-        Verify that the ProgramCertificateIssuer makes a call to the `_emit_program_certificate_signal` function as
-        expected when the system creates or updates a UserCredential.
+        Verify that the system makes a call to the `_emit_program_certificate_signal` function as expected when the
+        system creates or updates a UserCredential.
         """
         self.site_config.records_enabled = False
         self.site_config.save()
 
-        user = UserFactory()
-        self.issuer.issue_credential(self.certificate, user.username)
+        self.issuer.issue_credential(self.certificate, self.user.username)
 
         # retrieve the credential generated for verifications
-        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+        user_credential = UserCredential.objects.get(username=self.user.username, credential_id=self.certificate.id)
         assert mock_emit.call_count == 1
-        mock_emit.assert_called_with(user.username, user_credential, "awarded", self.certificate)
+        mock_emit.assert_called_with(self.user, user_credential, "awarded", self.certificate)
 
-    @override_settings(SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL=True)
     @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_AWARDED.send_event")
     def test_emit_program_certificate_signal_certificate_awarded(self, mock_send):
         """
@@ -259,15 +263,16 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         self.site_config.records_enabled = False
         self.site_config.save()
 
-        user = UserFactory()
-        self.issuer.issue_credential(self.certificate, user.username)
-        user_credential = UserCredential.objects.get(username=user.username, credential_id=self.certificate.id)
+        self.issuer.issue_credential(self.certificate, self.user.username)
+        user_credential = UserCredential.objects.get(username=self.user.username, credential_id=self.certificate.id)
 
         expected_event_data = ProgramCertificateData(
             user=UserData(
-                pii=UserPersonalData(username=user.username, email=user.email, name=user.get_full_name()),
-                id=user.lms_user_id,
-                is_active=user.is_active,
+                pii=UserPersonalData(
+                    username=self.user.username, email=self.user.email, name=self.user.get_full_name()
+                ),
+                id=self.user.lms_user_id,
+                is_active=self.user.is_active,
             ),
             program=ProgramData(
                 uuid=str(self.program.uuid), title=self.program.title, program_type=self.program.type_slug
@@ -281,7 +286,6 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         mock_call_args = mock_send.mock_calls[0].kwargs
         assert expected_event_data == mock_call_args["program_certificate"]
 
-    @override_settings(SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL=True)
     @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_REVOKED.send_event")
     def test_emit_program_certificate_signal_certificate_revoked(self, mock_send):
         """
@@ -312,7 +316,6 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         mock_call_args = mock_send.mock_calls[0].kwargs
         assert expected_event_data == mock_call_args["program_certificate"]
 
-    @override_settings(SEND_PROGRAM_CERTIFICATE_REVOKED_SIGNAL=False)
     @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_REVOKED.send_event")
     def test_emit_program_certificate_signal_certificate_revoked_signal_disabled(self, mock_send):
         """
@@ -329,7 +332,6 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         assert user_credential
         assert mock_send.call_count == 0
 
-    @override_settings(SEND_PROGRAM_CERTIFICATE_AWARDED_SIGNAL=True)
     @mock.patch("credentials.apps.credentials.issuers.PROGRAM_CERTIFICATE_AWARDED.send_event")
     def test_emit_program_certificate_signal_user_dne(self, mock_send):
         """
@@ -349,6 +351,111 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
 
         assert expected_error_message in log.records[0].msg
         assert mock_send.call_count == 0
+
+    @mock.patch("credentials.apps.credentials.issuers.SegmentClient", autospec=True)
+    def test_emit_segment_event_credential_created(self, mock_segment_client):
+        """
+        A test that verifies the contents and event type of a Segment event that is emit when learner's program
+        credential is awarded.
+        """
+        self.site_config.segment_key = "a super secure password"
+        self.site_config.save()
+
+        user_credential = self.issuer.issue_credential(self.certificate, self.user.username)
+
+        expected_event_name = "edx.bi.credentials.credential_issuers.program_certificate_created"
+        expected_event_properties = {
+            "category": "credentials",
+            "user": {
+                "username": self.user.username,
+                "lms_user_id": self.user.lms_user_id,
+            },
+            "program": {
+                "uuid": str(self.certificate.program.uuid),
+                "title": self.certificate.program.title,
+                "program_type": self.certificate.program.type_slug,
+            },
+            "uuid": str(user_credential.uuid),
+            "status": "awarded",
+            "url": f"https://{self.certificate.site.domain}/credentials/{str(user_credential.uuid).replace('-', '')}/",
+            "timestamp": user_credential.modified,
+        }
+
+        mock_segment_client_method_calls = mock_segment_client.method_calls
+        assert len(mock_segment_client_method_calls) == 1
+        call_args = mock_segment_client_method_calls[0].kwargs
+        assert call_args["event"] == expected_event_name
+        assert call_args["properties"] == expected_event_properties
+
+    @mock.patch("credentials.apps.credentials.issuers.SegmentClient", autospec=True)
+    def test_emit_segment_event_credential_updated(self, mock_segment_client):
+        """
+        A test that verifies the contents and event type of a Segment event that is emit when learner's program
+        credential is updated.
+        """
+        self.site_config.segment_key = "a super secure password"
+        self.site_config.save()
+
+        # create a credential belonging to our test user before we attempt to update it using the functions under test
+        UserCredentialFactory(username=self.user.username, credential=self.certificate)
+        user_credential = self.issuer.issue_credential(
+            self.certificate,
+            self.user.username,
+            status=UserCredentialStatus.REVOKED,
+        )
+
+        expected_event_name = "edx.bi.credentials.credential_issuers.program_certificate_updated"
+        expected_event_properties = {
+            "category": "credentials",
+            "user": {
+                "username": self.user.username,
+                "lms_user_id": self.user.lms_user_id,
+            },
+            "program": {
+                "uuid": str(self.certificate.program.uuid),
+                "title": self.certificate.program.title,
+                "program_type": self.certificate.program.type_slug,
+            },
+            "uuid": str(user_credential.uuid),
+            "status": "revoked",
+            "url": f"https://{self.certificate.site.domain}/credentials/{str(user_credential.uuid).replace('-', '')}/",
+            "timestamp": user_credential.modified,
+        }
+
+        mock_segment_client_method_calls = mock_segment_client.method_calls
+        assert len(mock_segment_client_method_calls) == 1
+        call_args = mock_segment_client_method_calls[0].kwargs
+        assert call_args["event"] == expected_event_name
+        assert call_args["properties"] == expected_event_properties
+
+    @mock.patch("credentials.apps.credentials.issuers.SegmentClient", autospec=True)
+    def test_emit_segment_event_segment_not_configured(self, mock_segment_client):
+        """
+        A test that verifies if Segment is not setup, we don't try to send an event.
+        """
+        self.issuer.issue_credential(self.certificate, self.user.username)
+
+        assert mock_segment_client.call_count == 0
+        mock_segment_client_method_calls = mock_segment_client.method_calls
+        assert len(mock_segment_client_method_calls) == 0
+
+    def test_emit_segment_event_use_dne(self):
+        """
+        A test that verifies an edge case where a Segment event is not emit due to an unrecognized learner.
+        """
+        self.site_config.records_enabled = False
+        self.site_config.save()
+
+        expected_log_message = (
+            "Unable to send a Segment event for user with username [mistadobalina]. No user found matching this "
+            "username"
+        )
+
+        with LogCapture() as log:
+            self.issuer.issue_credential(self.certificate, "mistadobalina")
+
+        log_messages = [log.msg for log in log.records]
+        assert expected_log_message in log_messages
 
 
 class CourseCertificateIssuerTests(CertificateIssuerBase, TestCase):

--- a/credentials/apps/credentials/utils.py
+++ b/credentials/apps/credentials/utils.py
@@ -301,7 +301,7 @@ def send_program_certificate_created_message(username, program_certificate, lms_
         ace.send(msg)
     # We wouldn't want any issues that arise from formatting or sending this email message to interrupt the process
     # of issuing a learner their Program Certificate. We cast a wide net for exceptions here for this reason.
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception as ex:
         log.exception(
             f"Unable to send email to learner with id: [{user.id}] for Program [{program_uuid}]. "
             f"Error occurred while attempting to format or send message: {ex}"


### PR DESCRIPTION
[APER-3017]

Adds a feature to Credentials where the system will emit a Segment event (if configured) when a program credential is awarded or updated.

New events added with this PR:
* `edx.bi.credentials.credential_issuers.program_certificate_updated`
* `edx.bi.credentials.credential_issuers.program_certificate_created`

Additionally, an example of the properties sent with the event:
```
{
    "category": "credentials",
    "user":
    {
        "username": "edx",
        "lms_user_id": 3
    },
    "program":
    {
        "uuid": "83c7ae34-5e74-44f1-a837-7eb3426b3478",
        "title": "Best Program Ever",
        "program_type": "microbachelors"
    },
    "uuid": "bd4ffd35-8c68-45c0-9eb8-9b8652411ba4",
    "status": "awarded",
    "url": "{blah}/credentials/bd4ffd358c6845c09eb89b8652411ba4/",
    "timestamp": "2023-11-01T19:21:08.300353+00:00"
}
```

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
