### PR TITLE
fix: send lms_user_id as `user_id` and not `anonymous_id`

### DIFF
--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -332,7 +332,7 @@ class ProgramCertificateIssuer(AbstractCredentialIssuer):
             }
 
             segment_client.track(
-                anonymous_id=user.lms_user_id,
+                user_id=user.lms_user_id,
                 event=event_name,
                 properties=event_properties,
             )

--- a/credentials/apps/credentials/tests/test_issuer.py
+++ b/credentials/apps/credentials/tests/test_issuer.py
@@ -384,7 +384,7 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         mock_segment_client_method_calls = mock_segment_client.method_calls
         assert len(mock_segment_client_method_calls) == 1
         call_args = mock_segment_client_method_calls[0].kwargs
-        assert call_args["anonymous_id"] == self.user.lms_user_id
+        assert call_args["user_id"] == self.user.lms_user_id
         assert call_args["event"] == expected_event_name
         assert call_args["properties"] == expected_event_properties
 
@@ -426,7 +426,7 @@ class ProgramCertificateIssuerTests(CertificateIssuerBase, TestCase):
         mock_segment_client_method_calls = mock_segment_client.method_calls
         assert len(mock_segment_client_method_calls) == 1
         call_args = mock_segment_client_method_calls[0].kwargs
-        assert call_args["anonymous_id"] == self.user.lms_user_id
+        assert call_args["user_id"] == self.user.lms_user_id
         assert call_args["event"] == expected_event_name
         assert call_args["properties"] == expected_event_properties
 


### PR DESCRIPTION
This is a fix for a recent change as part of PR #2276. We should pass the LMS User Id as `user_id` and not the `anonymous_id`.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
