### PR TITLE
fix: attempt to fix Credentials docker image build by reverting changes from #1912

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ FROM ubuntu:focal as base
 
 # If you add a package here please include a comment above describing what it is used for
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y software-properties-common && \
+    apt-get install -y software-properties-common && \
     apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
-    apt-get upgrade -qy && apt-get install --no-install-recommends language-pack-en locales gettext git \
+    apt-get upgrade -qy && apt-get install language-pack-en locales gettext git \
     python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip pkg-config -qy && \
     rm -rf /var/lib/apt/lists/*
 
@@ -28,11 +28,11 @@ RUN python3.8 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Create Node env
-RUN pip install --no-cache-dir nodeenv
+RUN pip install nodeenv
 ENV NODE_ENV=/edx/app/credentials/nodeenvs/credentials
 RUN nodeenv $NODE_ENV --node=18.17.1 --prebuilt
 ENV PATH="$NODE_ENV/bin:$PATH"
-RUN npm install -g npm@9.x.x && npm cache clean --force;
+RUN npm install -g npm@9.x.x
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -61,8 +61,8 @@ COPY requirements/production.txt /edx/app/credentials/credentials/requirements/p
 COPY requirements/pip_tools.txt /edx/app/credentials/credentials/requirements/pip_tools.txt
 
 # Dependencies are installed as root so they cannot be modified by the application user.
-RUN pip install --no-cache-dir -r requirements/pip_tools.txt
-RUN pip install --no-cache-dir -r requirements/production.txt
+RUN pip install -r requirements/pip_tools.txt
+RUN pip install -r requirements/production.txt
 
 RUN mkdir -p /edx/var/log
 
@@ -71,7 +71,7 @@ RUN mkdir -p /edx/var/log
 COPY . /edx/app/credentials/credentials
 
 # Install dependencies in node_modules directory
-RUN npm install --no-save && npm cache clean --force;
+RUN npm install --no-save
 ENV NODE_BIN=/edx/app/credentials/credentials/node_modules
 ENV PATH="$NODE_BIN/.bin:$PATH"
 # Run webpack
@@ -92,7 +92,7 @@ CMD gunicorn --workers=2 --name credentials -c /edx/app/credentials/credentials/
 FROM base as dev
 USER root
 ENV DJANGO_SETTINGS_MODULE credentials.settings.devstack
-RUN pip install --no-cache-dir -r /edx/app/credentials/credentials/requirements/dev.txt
+RUN pip install -r /edx/app/credentials/credentials/requirements/dev.txt
 
 # Temporary compatibility hack while devstack is supporting
 # both the old `edxops/credentials` image and this image:


### PR DESCRIPTION
In early October, we accepted an to the public Credentials Dockerfile presented through an OSPR. The purpose was to reduce the overall size of the Credentials Docker image.

However, shortly after this point, the Credentials image build started to fail.

The error we've been observing is...
```
#35 [linux/arm64 base  6/25] RUN npm install -g npm@9.x.x && npm cache clean --force;
#35 116.3 
#35 116.3 removed 16 packages, and changed 46 packages in 2m
#35 116.3 
#35 116.3 28 packages are looking for funding
#35 116.3   run `npm fund` for details
#35 136.6 npm WARN using --force Recommended protections disabled.
#35 152.1 npm ERR! code ENOTEMPTY
#35 152.1 npm ERR! syscall rmdir
#35 152.1 npm ERR! path /root/.npm/_cacache
#35 152.2 npm ERR! errno -39
#35 152.3 npm ERR! ENOTEMPTY: directory not empty, rmdir '/root/.npm/_cacache'
#35 152.3 
#35 152.3 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-11-06T20_36_08_037Z-debug-0.log
#35 ERROR: process "/bin/sh -c npm install -g npm@9.x.x && npm cache clean --force;" did not complete successfully: exit code: 217
------
 > [linux/arm64 base  6/25] RUN npm install -g npm@9.x.x && npm cache clean --force;:
116.3 
116.3 28 packages are looking for funding
116.3   run `npm fund` for details
136.6 npm WARN using --force Recommended protections disabled.
152.1 npm ERR! code ENOTEMPTY
152.1 npm ERR! syscall rmdir
152.1 npm ERR! path /root/.npm/_cacache
 ERR! ENOTEMPTY: directory not empty, rmdir '/root/.npm/_cacache'
152.3 
152.3 npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-11-06T20_36_08_037Z-debug-0.log
------
Dockerfile:35
--------------------
  33 |     RUN nodeenv $NODE_ENV --node=18.17.1 --prebuilt
  34 |     ENV PATH="$NODE_ENV/bin:$PATH"
  35 | >>> RUN npm install -g npm@9.x.x && npm cache clean --force;
  36 |     
  37 |     RUN locale-gen en_US.UTF-8
--------------------
ERROR: failed to solve: process "/bin/sh -c npm install -g npm@9.x.x && npm cache clean --force;" did not complete successfully: exit code: 217
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c npm install -g npm@9.x.x && npm cache clean --force;" did not complete successfully: exit code: 217
```

In a first attempt to troubleshoot the issues, I am removing the accepted changes from PR #1912 to see if this resolves the problem. We can then look at reintroducing them if needed.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
