### PR TITLE
feat: update Segment package in Credentials

### DIFF
--- a/credentials/apps/credentials/issuers.py
+++ b/credentials/apps/credentials/issuers.py
@@ -6,12 +6,12 @@ import abc
 import logging
 from datetime import timezone
 
-from analytics.client import Client as SegmentClient
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from openedx_events.learning.data import ProgramCertificateData, ProgramData, UserData, UserPersonalData
 from openedx_events.learning.signals import PROGRAM_CERTIFICATE_AWARDED, PROGRAM_CERTIFICATE_REVOKED
+from segment.analytics.client import Client as SegmentClient
 
 from credentials.apps.api.exceptions import DuplicateAttributeError
 from credentials.apps.core.api import get_user_by_username

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -5,7 +5,6 @@ import logging
 import urllib.parse
 from uuid import uuid4
 
-from analytics.client import Client as SegmentClient
 from django import http
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -18,6 +17,7 @@ from django.utils.translation import gettext as _
 from django.views.generic import TemplateView, View
 from edx_ace import Recipient, ace
 from ratelimit.decorators import ratelimit
+from segment.analytics.client import Client as SegmentClient
 
 from credentials.apps.catalog.models import Pathway, Program
 from credentials.apps.core.api import get_user_by_username

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -69,7 +69,13 @@ BACKEND_SERVICE_EDX_OAUTH2_PROVIDER_URL = os.environ.get(
     "http://edx.devstack.lms:18000/oauth2",
 )
 
-CORS_ORIGIN_WHITELIST = ("http://localhost:1990", "http://localhost:18450")
+CORS_ORIGIN_WHITELIST = [
+    "http://localhost:1990",  # Learner Record MFE
+    "http://localhost:18450",  # Subscriptions IDA
+]
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:1990",  # Learner Record MFE
+]
 
 SOCIAL_AUTH_REDIRECT_IS_HTTPS = str2bool(os.environ.get("SOCIAL_AUTH_REDIRECT_IS_HTTPS", False))
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -4,16 +4,12 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.txt
-    #   -r requirements/production.txt
 asgiref==3.7.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   -r requirements/dev.txt
@@ -26,11 +22,11 @@ attrs==23.1.0
     #   edx-ace
     #   jsonschema
     #   openedx-events
-backoff==1.10.0
+backoff==2.2.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   analytics-python
+    #   segment-analytics-python
 backports-zoneinfo==0.2.1
     # via
     #   -r requirements/dev.txt
@@ -46,11 +42,11 @@ bleach==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.28.85
+boto3==1.29.0
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.31.85
+botocore==1.32.0
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -181,7 +177,7 @@ django-appconf==1.0.5
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django-statici18n
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -299,7 +295,7 @@ edx-django-utils==5.8.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -336,7 +332,7 @@ exceptiongroup==1.1.3
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/dev.txt
-faker==20.0.0
+faker==20.0.3
     # via
     #   -r requirements/dev.txt
     #   factory-boy
@@ -425,7 +421,7 @@ monotonic==1.6
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   analytics-python
+    #   segment-analytics-python
 mypy-extensions==1.0.0
     # via
     #   -r requirements/dev.txt
@@ -456,7 +452,7 @@ openedx-atlas==0.5.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-openedx-events==9.0.1
+openedx-events==9.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -594,10 +590,10 @@ python-dateutil==2.8.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   analytics-python
     #   botocore
     #   edx-ace
     #   faker
+    #   segment-analytics-python
 python-dotenv==0.21.1
     # via
     #   -r requirements/dev.txt
@@ -644,7 +640,6 @@ requests==2.31.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   analytics-python
     #   coreapi
     #   docker
     #   docker-compose
@@ -653,6 +648,7 @@ requests==2.31.0
     #   requests-oauthlib
     #   responses
     #   sailthru-client
+    #   segment-analytics-python
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
@@ -660,7 +656,7 @@ requests-oauthlib==1.3.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.24.1
     # via -r requirements/dev.txt
 s3transfer==0.7.0
     # via
@@ -671,6 +667,10 @@ sailthru-client==2.2.3
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-ace
+segment-analytics-python==2.2.3
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
 semantic-version==2.10.0
     # via
     #   -r requirements/dev.txt
@@ -686,7 +686,6 @@ six==1.16.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   analytics-python
     #   bleach
     #   dockerpty
     #   edx-ace
@@ -747,7 +746,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -r requirements/dev.txt
     #   pylint

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -9,7 +9,6 @@
 
 -c constraints.txt
 
-analytics-python
 bleach
 coreapi
 didkit
@@ -48,6 +47,7 @@ pymemcache
 pytz
 qrcode
 requests
+segment-analytics-python
 social-auth-app-django
 xss-utils
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,18 +4,16 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
 asgiref==3.7.2
-    # via django
+    # via
+    #   django
+    #   django-cors-headers
 attrs==23.1.0
     # via
     #   edx-ace
     #   openedx-events
-backoff==1.10.0
-    # via analytics-python
+backoff==2.2.1
+    # via segment-analytics-python
 backports-zoneinfo==0.2.1
     # via django
 bleach==6.1.0
@@ -80,7 +78,7 @@ django==4.2.7
     #   xss-utils
 django-appconf==1.0.5
     # via django-statici18n
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/base.in
 django-crum==0.7.9
     # via
@@ -140,7 +138,7 @@ edx-django-utils==5.8.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via -r requirements/base.in
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.in
@@ -178,7 +176,7 @@ markdown==3.5.1
 markupsafe==2.1.3
     # via jinja2
 monotonic==1.6
-    # via analytics-python
+    # via segment-analytics-python
 mysqlclient==2.2.0
     # via -r requirements/base.in
 newrelic==9.1.2
@@ -193,7 +191,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 openedx-atlas==0.5.0
     # via -r requirements/base.in
-openedx-events==9.0.1
+openedx-events==9.1.0
     # via edx-event-bus-kafka
 packaging==23.2
     # via drf-yasg
@@ -229,8 +227,8 @@ pypng==0.20220715.0
     # via qrcode
 python-dateutil==2.8.2
     # via
-    #   analytics-python
     #   edx-ace
+    #   segment-analytics-python
 python-memcached==1.59
     # via -r requirements/base.in
 python-slugify==8.0.1
@@ -254,18 +252,20 @@ qrcode==7.4.2
 requests==2.31.0
     # via
     #   -r requirements/base.in
-    #   analytics-python
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
     #   sailthru-client
+    #   segment-analytics-python
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via social-auth-core
 sailthru-client==2.2.3
     # via edx-ace
+segment-analytics-python==2.2.3
+    # via -r requirements/base.in
 semantic-version==2.10.0
     # via edx-drf-extensions
 simplejson==3.19.2
@@ -274,7 +274,6 @@ simplejson==3.19.2
     #   sailthru-client
 six==1.16.0
     # via
-    #   analytics-python
     #   bleach
     #   edx-ace
     #   edx-auth-backends

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,10 +23,6 @@ django-ratelimit<4.0
 # re-evaluated as part of APER-2220
 sphinx<6.0
 
-# Pinning analytics-python to 1.4.0 to avoid an undocumented update to the project (w/ version number `1.4.post1`?).
-# It looks like we should be migrating to the 2.x version of the library (whose name has changed).
-analytics-python<=1.4.0
-
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,14 +4,11 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
 asgiref==3.7.2
     # via
     #   -r requirements/test.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   -r requirements/test.txt
@@ -23,10 +20,10 @@ attrs==23.1.0
     #   edx-ace
     #   jsonschema
     #   openedx-events
-backoff==1.10.0
+backoff==2.2.1
     # via
     #   -r requirements/test.txt
-    #   analytics-python
+    #   segment-analytics-python
 backports-zoneinfo==0.2.1
     # via
     #   -r requirements/test.txt
@@ -147,7 +144,7 @@ django-appconf==1.0.5
     # via
     #   -r requirements/test.txt
     #   django-statici18n
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/test.txt
 django-crum==0.7.9
     # via
@@ -222,7 +219,7 @@ edx-django-utils==5.8.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via -r requirements/test.txt
 edx-event-bus-kafka==5.5.0
     # via -r requirements/test.txt
@@ -251,7 +248,7 @@ exceptiongroup==1.1.3
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==20.0.0
+faker==20.0.3
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -314,7 +311,7 @@ mccabe==0.7.0
 monotonic==1.6
     # via
     #   -r requirements/test.txt
-    #   analytics-python
+    #   segment-analytics-python
 mypy-extensions==1.0.0
     # via
     #   -r requirements/test.txt
@@ -336,7 +333,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 openedx-atlas==0.5.0
     # via -r requirements/test.txt
-openedx-events==9.0.1
+openedx-events==9.1.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -451,9 +448,9 @@ pytest-django==4.7.0
 python-dateutil==2.8.2
     # via
     #   -r requirements/test.txt
-    #   analytics-python
     #   edx-ace
     #   faker
+    #   segment-analytics-python
 python-dotenv==0.21.1
     # via docker-compose
 python-memcached==1.59
@@ -488,7 +485,6 @@ qrcode==7.4.2
 requests==2.31.0
     # via
     #   -r requirements/test.txt
-    #   analytics-python
     #   coreapi
     #   docker
     #   docker-compose
@@ -497,18 +493,21 @@ requests==2.31.0
     #   requests-oauthlib
     #   responses
     #   sailthru-client
+    #   segment-analytics-python
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/test.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.24.1
     # via -r requirements/test.txt
 sailthru-client==2.2.3
     # via
     #   -r requirements/test.txt
     #   edx-ace
+segment-analytics-python==2.2.3
+    # via -r requirements/test.txt
 semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
@@ -521,7 +520,6 @@ simplejson==3.19.2
 six==1.16.0
     # via
     #   -r requirements/test.txt
-    #   analytics-python
     #   bleach
     #   dockerpty
     #   edx-ace
@@ -574,7 +572,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via
     #   -r requirements/test.txt
     #   pylint

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,32 +4,29 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
+    #   django-cors-headers
 attrs==23.1.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
     #   openedx-events
-backoff==1.10.0
+backoff==2.2.1
     # via
     #   -r requirements/base.txt
-    #   analytics-python
+    #   segment-analytics-python
 backports-zoneinfo==0.2.1
     # via
     #   -r requirements/base.txt
     #   django
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.28.85
+boto3==1.29.0
     # via django-ses
-botocore==1.31.85
+botocore==1.32.0
     # via
     #   boto3
     #   s3transfer
@@ -108,7 +105,7 @@ django-appconf==1.0.5
     # via
     #   -r requirements/base.txt
     #   django-statici18n
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -173,7 +170,7 @@ edx-django-utils==5.8.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via -r requirements/base.txt
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.txt
@@ -241,7 +238,7 @@ markupsafe==2.1.3
 monotonic==1.6
     # via
     #   -r requirements/base.txt
-    #   analytics-python
+    #   segment-analytics-python
 mysqlclient==2.2.0
     # via -r requirements/base.txt
 newrelic==9.1.2
@@ -262,7 +259,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 openedx-atlas==0.5.0
     # via -r requirements/base.txt
-openedx-events==9.0.1
+openedx-events==9.1.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -321,9 +318,9 @@ pypng==0.20220715.0
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
-    #   analytics-python
     #   botocore
     #   edx-ace
+    #   segment-analytics-python
 python-memcached==1.59
     # via -r requirements/base.txt
 python-slugify==8.0.1
@@ -354,12 +351,12 @@ qrcode==7.4.2
 requests==2.31.0
     # via
     #   -r requirements/base.txt
-    #   analytics-python
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
     #   sailthru-client
+    #   segment-analytics-python
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
@@ -372,6 +369,8 @@ sailthru-client==2.2.3
     # via
     #   -r requirements/base.txt
     #   edx-ace
+segment-analytics-python==2.2.3
+    # via -r requirements/base.txt
 semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
@@ -384,7 +383,6 @@ simplejson==3.19.2
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   analytics-python
     #   bleach
     #   edx-ace
     #   edx-auth-backends

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,14 +4,11 @@
 #
 #    make upgrade
 #
-analytics-python==1.4.0
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
 asgiref==3.7.2
     # via
     #   -r requirements/base.txt
     #   django
+    #   django-cors-headers
 astroid==3.0.1
     # via
     #   pylint
@@ -21,10 +18,10 @@ attrs==23.1.0
     #   -r requirements/base.txt
     #   edx-ace
     #   openedx-events
-backoff==1.10.0
+backoff==2.2.1
     # via
     #   -r requirements/base.txt
-    #   analytics-python
+    #   segment-analytics-python
 backports-zoneinfo==0.2.1
     # via
     #   -r requirements/base.txt
@@ -127,7 +124,7 @@ django-appconf==1.0.5
     # via
     #   -r requirements/base.txt
     #   django-statici18n
-django-cors-headers==4.3.0
+django-cors-headers==4.3.1
     # via -r requirements/base.txt
 django-crum==0.7.9
     # via
@@ -190,7 +187,7 @@ edx-django-utils==5.8.0
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
-edx-drf-extensions==8.13.0
+edx-drf-extensions==8.13.1
     # via -r requirements/base.txt
 edx-event-bus-kafka==5.5.0
     # via -r requirements/base.txt
@@ -216,7 +213,7 @@ exceptiongroup==1.1.3
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==20.0.0
+faker==20.0.3
     # via factory-boy
 fastavro==1.9.0
     # via
@@ -270,7 +267,7 @@ mccabe==0.7.0
 monotonic==1.6
     # via
     #   -r requirements/base.txt
-    #   analytics-python
+    #   segment-analytics-python
 mypy-extensions==1.0.0
     # via black
 mysqlclient==2.2.0
@@ -290,7 +287,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 openedx-atlas==0.5.0
     # via -r requirements/base.txt
-openedx-events==9.0.1
+openedx-events==9.1.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -387,9 +384,9 @@ pytest-django==4.7.0
 python-dateutil==2.8.2
     # via
     #   -r requirements/base.txt
-    #   analytics-python
     #   edx-ace
     #   faker
+    #   segment-analytics-python
 python-memcached==1.59
     # via -r requirements/base.txt
 python-slugify==8.0.1
@@ -419,25 +416,27 @@ qrcode==7.4.2
 requests==2.31.0
     # via
     #   -r requirements/base.txt
-    #   analytics-python
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   requests-oauthlib
     #   responses
     #   sailthru-client
+    #   segment-analytics-python
     #   slumber
     #   social-auth-core
 requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-responses==0.24.0
+responses==0.24.1
     # via -r requirements/test.in
 sailthru-client==2.2.3
     # via
     #   -r requirements/base.txt
     #   edx-ace
+segment-analytics-python==2.2.3
+    # via -r requirements/base.txt
 semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
@@ -450,7 +449,6 @@ simplejson==3.19.2
 six==1.16.0
     # via
     #   -r requirements/base.txt
-    #   analytics-python
     #   bleach
     #   edx-ace
     #   edx-auth-backends
@@ -496,7 +494,7 @@ tomli==2.0.1
     #   pyproject-api
     #   pytest
     #   tox
-tomlkit==0.12.2
+tomlkit==0.12.3
     # via pylint
 tox==4.11.3
     # via -r requirements/test.in


### PR DESCRIPTION
[APER-3056]

This PR features an upgrade of the Segment package in Credentials. The previous package (`analytics-python`) has been renamed, the previous package is no longer supported or under active development.

* Remove constraint on `analytics-python` in `constraints.txt`
* Remove the `analytics-python` package from `base.in`
* Adds the `segment-analytics-python` package to `base.in`
* Regenerate our requirements files after updates
* Update package imports where appropriate
* Fixes an unrelated issue where I was unable to create a shared program record with Credentials in devstack due to missing configuration

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
