### PR TITLE
feat: remove constraints for 'sphinx' and 'urllib', upgrade to latest versions

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -42,11 +42,11 @@ bleach==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.29.0
+boto3==1.7.84
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.32.0
+botocore==1.10.84
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -258,6 +258,10 @@ docopt==0.6.2
     # via
     #   -r requirements/dev.txt
     #   docker-compose
+docutils==0.20.1
+    # via
+    #   -r requirements/production.txt
+    #   botocore
 drf-jwt==1.19.2
     # via
     #   -r requirements/dev.txt
@@ -390,7 +394,7 @@ jinja2==3.1.2
     #   -r requirements/production.txt
     #   code-annotations
     #   coreschema
-jmespath==1.0.1
+jmespath==0.10.0
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -658,7 +662,7 @@ requests-oauthlib==1.3.1
     #   social-auth-core
 responses==0.24.1
     # via -r requirements/dev.txt
-s3transfer==0.7.0
+s3transfer==0.1.13
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -769,12 +773,10 @@ uritemplate==4.1.1
     #   -r requirements/production.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.18
+urllib3==2.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   botocore
     #   docker
     #   requests
     #   responses

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -310,10 +310,8 @@ uritemplate==4.1.1
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.26.18
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
+urllib3==2.1.0
+    # via requests
 webencodings==0.5.1
     # via bleach
 xss-utils==0.5.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,14 +19,6 @@ pyyaml<6.0
 # re-evaluated as part of APER-2169.
 django-ratelimit<4.0
 
-# Version of sphinx is pinned to v5.3.0 because of breaking changes in v6.
-# re-evaluated as part of APER-2220
-sphinx<6.0
-
-# Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
-# APER-2422
-urllib3<2
-
 # social-auth-app-django versions after 5.2.0 has a problematic migration that will cause issues deployments with large
 # `social_auth_usersocialauth` tables
 social-auth-app-django<5.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -593,9 +593,8 @@ uritemplate==4.1.1
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.18
+urllib3==2.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   docker
     #   requests

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -54,9 +54,8 @@ snowballstemmer==2.2.0
     # via sphinx
 soupsieve==2.5
     # via beautifulsoup4
-sphinx==5.3.0
+sphinx==6.2.1
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/docs.in
     #   pydata-sphinx-theme
     #   sphinx-book-theme
@@ -76,9 +75,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 typing-extensions==4.8.0
     # via pydata-sphinx-theme
-urllib3==1.26.18
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
+urllib3==2.1.0
+    # via requests
 zipp==3.17.0
     # via importlib-metadata

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -24,9 +24,9 @@ backports-zoneinfo==0.2.1
     #   django
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.29.0
+boto3==1.7.84
     # via django-ses
-botocore==1.32.0
+botocore==1.10.84
     # via
     #   boto3
     #   s3transfer
@@ -147,6 +147,8 @@ djangorestframework==3.14.0
     #   drf-jwt
     #   drf-yasg
     #   edx-drf-extensions
+docutils==0.20.1
+    # via botocore
 drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
@@ -221,7 +223,7 @@ jinja2==3.1.2
     #   -r requirements/base.txt
     #   code-annotations
     #   coreschema
-jmespath==1.0.1
+jmespath==0.10.0
     # via
     #   boto3
     #   botocore
@@ -363,7 +365,7 @@ requests-oauthlib==1.3.1
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-s3transfer==0.7.0
+s3transfer==0.1.13
     # via boto3
 sailthru-client==2.2.3
     # via
@@ -429,11 +431,9 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.18
+urllib3==2.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-    #   botocore
     #   requests
 webencodings==0.5.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -513,9 +513,8 @@ uritemplate==4.1.1
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-urllib3==1.26.18
+urllib3==2.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   requests
     #   responses


### PR DESCRIPTION
[APER-2220] & [APER-2422]

Previously, upgrades to the `sphinx` and `urllib` packages had resulted in compatibility issues with other packages. These issues look to have been resolved and we are clear to upgrade them now.

* remove `sphinx` constraint and upgrade to the latest version
* remove `urllib` constraint and upgrade to the latest version

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
