### PR TITLE
fix: (re)pin urllib to 1.x release

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -19,6 +19,10 @@ pyyaml<6.0
 # re-evaluated as part of APER-2169.
 django-ratelimit<4.0
 
+# Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
+# APER-2422
+urllib3<2
+
 # social-auth-app-django versions after 5.2.0 has a problematic migration that will cause issues deployments with large
 # `social_auth_usersocialauth` tables
 social-auth-app-django<5.3


### PR DESCRIPTION
Upgrading `urllib3` to the 2.x versions introduced some weird issues with boto, causing an error to be thrown while rendering program credentials.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
