### PR TITLE
feat: upgrade `django-ratelimit' to 4.x

### DIFF
--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -15,8 +15,8 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext as _
 from django.views.generic import TemplateView, View
+from django_ratelimit.decorators import ratelimit
 from edx_ace import Recipient, ace
-from ratelimit.decorators import ratelimit
 from segment.analytics.client import Client as SegmentClient
 
 from credentials.apps.catalog.models import Pathway, Program

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -98,7 +98,7 @@ MIDDLEWARE = (
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "social_django.middleware.SocialAuthExceptionMiddleware",
     "waffle.middleware.WaffleMiddleware",
-    "ratelimit.middleware.RatelimitMiddleware",
+    "django_ratelimit.middleware.RatelimitMiddleware",
     "edx_django_utils.cache.middleware.TieredCacheMiddleware",
     "edx_rest_framework_extensions.middleware.RequestMetricsMiddleware",
     "edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware",

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -197,9 +197,8 @@ django-filter==23.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-django-ratelimit==3.0.1
+django-ratelimit==4.1.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
 django-rest-swagger==2.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -88,10 +88,8 @@ django-extensions==3.2.3
     # via -r requirements/base.in
 django-filter==23.3
     # via -r requirements/base.in
-django-ratelimit==3.0.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+django-ratelimit==4.1.0
+    # via -r requirements/base.in
 django-rest-swagger==2.2.0
     # via -r requirements/base.in
 django-simple-history==3.4.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,10 +15,6 @@
 # re-evaluated as part of APER-1556.
 pyyaml<6.0
 
-# The update to django-ratelimit 4.x failed because of some breaking changes. Pinning to <4.x. This constraint will be
-# re-evaluated as part of APER-2169.
-django-ratelimit<4.0
-
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -157,10 +157,8 @@ django-extensions==3.2.3
     # via -r requirements/test.txt
 django-filter==23.3
     # via -r requirements/test.txt
-django-ratelimit==3.0.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
+django-ratelimit==4.1.0
+    # via -r requirements/test.txt
 django-rest-swagger==2.2.0
     # via -r requirements/test.txt
 django-simple-history==3.4.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -116,10 +116,8 @@ django-extensions==3.2.3
     # via -r requirements/base.txt
 django-filter==23.3
     # via -r requirements/base.txt
-django-ratelimit==3.0.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+django-ratelimit==4.1.0
+    # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
 django-ses==3.5.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -135,10 +135,8 @@ django-extensions==3.2.3
     # via -r requirements/base.txt
 django-filter==23.3
     # via -r requirements/base.txt
-django-ratelimit==3.0.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+django-ratelimit==4.1.0
+    # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
 django-simple-history==3.4.0


### PR DESCRIPTION
[APER-2169]

This PR removes a constraint on `django-ratelimit` in Credentials.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
