### PR TITLE
fix: display earned course credentials even if the grade is missing

### DIFF
--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -117,7 +117,7 @@ def _get_transformed_pathway_data(program, user):
     return pathway_data
 
 
-def _get_transformed_grade_data(program, user):
+def _get_transformed_grade_data(program, user):  # pylint: disable=too-many-statements
     """
     A utility function that gathers and transforms a learner's grade data for course-runs that are part of a Program.
     This data is used to render a learner's Program Record page.
@@ -185,37 +185,79 @@ def _get_transformed_grade_data(program, user):
     transformed_grade_data = []
     added_courses = set()
 
-    # add the course-run grade data to the response in the order that is maintained by the Program's sorted field
+    # create a collection of awarded credentials mapped to a *course*, this will help us build responses below and we
+    # need an easy way to know if a learner has earned a course credential in any eligible course runs of a specific
+    # course
+    awarded_course_credential_dict = {}
+    for user_credential in course_user_credentials:
+        if (
+            user_credential.status == UserCredentialStatus.AWARDED.value
+            and user_credential.credential.course_run in program_course_runs_set
+        ):
+            awarded_course_credential_dict[user_credential.credential.course_run.course] = user_credential
+
+    # Add the credential and grade data to the response in the order that is maintained by the Program's sorted field
     for course_run in program_course_runs:
         course = course_run.course
-        grade = highest_attempt_dict.get(course)
+        grade = highest_attempt_dict.get(course, None)
+        awarded_credential = awarded_course_credential_dict.get(course, None)
+        issue_date = None
+        if awarded_credential:
+            issue_date = get_credential_dates(awarded_credential, False)
 
-        # if the learner hasn't taken this course yet, or doesn't have a cert, we want to show empty values
-        if grade is None and course not in added_courses:
+        match = False
+        course_run_key = ""
+        course_attempts = ""
+        issue_date_formatted = ""
+        percent_grade = ""
+        letter_grade = ""
+        # Case 1: Learner has earned a credential and grade in a course-run of a course that is associated with this
+        # program
+        if (
+            awarded_credential
+            and awarded_credential.credential.course_run == course_run
+            and grade
+            and course not in added_courses
+        ):
+            match = True
+            course_run_key = course_run.key
+            course_attempts = num_attempts_dict[course]
+            issue_date_formatted = issue_date.isoformat() if issue_date else ""
+            percent_grade = float(grade.percent_grade)
+            letter_grade = grade.letter_grade or _("N/A")
+        # Case 2: Learner has earned a credential in, but we have no record of a grade for, a course-run of a course
+        # that is associated with this program
+        elif (
+            awarded_credential
+            and awarded_credential.credential.course_run == course_run
+            and not grade
+            and course not in added_courses
+        ):
+            match = True
+            course_run_key = course_run.key
+            issue_date_formatted = issue_date.isoformat() if issue_date else ""
+        # Case 3: Learner has a record of a grade in, but has not earned a Credential for, a course run of a course that
+        # is associated with this program. We actually don't have any logic for this case, as we only add grades to the
+        # "highest attempt" dictionary if-and-only-if the learner has earned a course credential in the course. See
+        # lines 177 -> 180 above. This comment is here for informational purposes when another maintainer looks at this
+        # code and thinks "hey, we forgot a case here!". The UI's behavior at this point is the same for Case #3 and
+        # Case #4 below, the grade is not shown and the Credential appears as "not earned".
+        ################################################################################################################
+        # Case 4: learner has no grades associated with, nor earned a course credential in, a course run of a course
+        # associated with this program
+        elif not grade and not awarded_credential and course not in added_courses:
+            match = True
+
+        if match:
             transformed_grade_data.append(
                 {
                     "name": course.title,
                     "school": ", ".join(course.owners.values_list("name", flat=True)),
-                    "attempts": 0,
-                    "course_id": "",
-                    "issue_date": "",
-                    "percent_grade": 0.0,
-                    "letter_grade": "",
-                }
-            )
-            added_courses.add(course)
-        elif grade is not None and grade.course_run == course_run:
-            user_credential = user_credential_dict.get(course_run.key)
-            issue_date = get_credential_dates(user_credential, False)
-            transformed_grade_data.append(
-                {
-                    "name": course_run.title,
-                    "school": ", ".join(course.owners.values_list("name", flat=True)),
-                    "attempts": num_attempts_dict[course],
-                    "course_id": course_run.key,
-                    "issue_date": issue_date.isoformat(),
-                    "percent_grade": float(grade.percent_grade),
-                    "letter_grade": grade.letter_grade or _("N/A"),
+                    "attempts": course_attempts,
+                    "course_id": course_run_key,
+                    "issue_date": issue_date_formatted,
+                    "percent_grade": percent_grade,
+                    "letter_grade": letter_grade,
                 }
             )
             added_courses.add(course)

--- a/credentials/apps/records/tests/test_api.py
+++ b/credentials/apps/records/tests/test_api.py
@@ -3,9 +3,11 @@ Tests for the `api.py` file of the Records Django app.
 """
 import datetime
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.template.defaultfilters import slugify
 from django.test import TestCase
+from edx_toggles.toggles.testutils import override_waffle_switch
 
 from credentials.apps.catalog.tests.factories import (
     CourseFactory,
@@ -20,6 +22,7 @@ from credentials.apps.credentials.api import get_credential_dates
 from credentials.apps.credentials.tests.factories import (
     CourseCertificateFactory,
     ProgramCertificateFactory,
+    UserCredentialAttributeFactory,
     UserCredentialFactory,
 )
 from credentials.apps.records.api import (
@@ -55,57 +58,103 @@ class ApiTests(SiteMixin, TestCase):
         self.user = UserFactory()
         # create the organization for the program
         self.org = OrganizationFactory.create(name="TestOrg1")
-        # create courses, course-runs, and course certificate configurations for our tests
-        self.course = CourseFactory.create(site=self.site)
-        self.course_runs = CourseRunFactory.create_batch(2, course=self.course)
-        self.course_cert_configs = [
-            CourseCertificateFactory.create(
-                course_id=course_run.key,
-                site=self.site,
-            )
-            for course_run in self.course_runs
-        ]
-        # create program and program certificate configuration for our tests
-        self.program = ProgramFactory(
-            title="TestProgram1",
-            course_runs=[self.course_runs[0], self.course_runs[1]],
+        # create three courses that we will use in our test cases
+        self.course1 = CourseFactory.create(site=self.site)
+        self.course2 = CourseFactory.create(site=self.site)
+        self.course3 = CourseFactory.create(site=self.site)
+        # create 2 course runs for course 1
+        self.course1_courserunA = CourseRunFactory(course=self.course1)
+        self.course1_courserunB = CourseRunFactory(course=self.course1)
+        # create 1 course run for course 2
+        self.course2_courserunA = CourseRunFactory(course=self.course2)
+        # create 1 course run for course 3
+        self.course3_courserunA = CourseRunFactory(course=self.course3)
+        # create a list of the course runs in program1
+        self.program1_course_runs = [self.course1_courserunA, self.course1_courserunB, self.course2_courserunA]
+        self.program1 = ProgramFactory(
+            title="Test Program 1",
+            course_runs=self.program1_course_runs,
             authoring_organizations=[self.org],
             site=self.site,
         )
-        self.program_cert_config = ProgramCertificateFactory.create(program_uuid=self.program.uuid, site=self.site)
-        # generate some grade data in the course-runs for our test user
-        self.grade_low = UserGradeFactory(
+        # create a list of the course runs in program2
+        self.program2_course_runs = [self.course1_courserunA, self.course3_courserunA]
+        self.program2 = ProgramFactory(
+            title="Test Program 2",
+            course_runs=self.program2_course_runs,
+            authoring_organizations=[self.org],
+            site=self.site,
+        )
+        # create course certificate configurations so we can grant credentials to the test learner
+        self.course_cert_course1_courserunA = CourseCertificateFactory(
+            course_id=self.course1_courserunA.key, site=self.site
+        )
+        self.course_cert_course1_courserunB = CourseCertificateFactory(
+            course_id=self.course1_courserunB.key, site=self.site
+        )
+        self.course_cert_course2_courserunA = CourseCertificateFactory(
+            course_id=self.course2_courserunA.key, site=self.site
+        )
+        self.course_cert_course3_courserunA = CourseCertificateFactory(
+            course_id=self.course3_courserunA.key, site=self.site
+        )
+        # create program certificate configurations so we can grant program credentials to the test learners
+        self.program1_cert_config = ProgramCertificateFactory.create(program_uuid=self.program1.uuid, site=self.site)
+        self.program2_cert_config = ProgramCertificateFactory.create(program_uuid=self.program2.uuid, site=self.site)
+        # create grade for learner in course-run1 of course1
+        self.course1_courserunA_grade = UserGradeFactory(
             username=self.user.username,
-            course_run=self.course_runs[0],
+            course_run=self.course1_courserunA,
             letter_grade="C",
             percent_grade=0.75,
         )
-        self.grade_high = UserGradeFactory(
+        self.course1_courserunB_grade = UserGradeFactory(
             username=self.user.username,
-            course_run=self.course_runs[1],
+            course_run=self.course1_courserunB,
             letter_grade="A",
             percent_grade=1.0,
         )
-        # award course certificate to our test user
-        self.course_certificiate_credentials = [
-            UserCredentialFactory.create(
-                username=self.user.username,
-                credential_content_type=self.COURSE_CERTIFICATE_CONTENT_TYPE,
-                credential=course_cert_config,
-            )
-            for course_cert_config in self.course_cert_configs
-        ]
-        self.program_certificate_credential = UserCredentialFactory.create(
+        self.course2_courserunA_grade = UserGradeFactory(
+            username=self.user.username,
+            course_run=self.course2_courserunA,
+            letter_grade="B",
+            percent_grade=0.85,
+        )
+        self.course3_courserunA_grade = UserGradeFactory(
+            username=self.user.username, course_run=self.course3_courserunA, letter_grade="A", percent_grade=0.91
+        )
+        # next, award the course and program credentials to our test learner
+        self.course_credential_course1_courserunA = UserCredentialFactory.create(
+            username=self.user.username,
+            credential_content_type=self.COURSE_CERTIFICATE_CONTENT_TYPE,
+            credential=self.course_cert_course1_courserunA,
+        )
+        self.course_credential_course1_courserunB = UserCredentialFactory.create(
+            username=self.user.username,
+            credential_content_type=self.COURSE_CERTIFICATE_CONTENT_TYPE,
+            credential=self.course_cert_course1_courserunB,
+        )
+        self.course_credential_course2_courserunA = UserCredentialFactory.create(
+            username=self.user.username,
+            credential_content_type=self.COURSE_CERTIFICATE_CONTENT_TYPE,
+            credential=self.course_cert_course2_courserunA,
+        )
+        self.course_credential_course3_courserunA = UserCredentialFactory.create(
+            username=self.user.username,
+            credential_content_type=self.COURSE_CERTIFICATE_CONTENT_TYPE,
+            credential=self.course_cert_course3_courserunA,
+        )
+        self.program_credential = UserCredentialFactory.create(
             username=self.user.username,
             credential_content_type=self.PROGRAM_CERTIFICATE_CONTENT_TYPE,
-            credential=self.program_cert_config,
+            credential=self.program1_cert_config,
         )
         # setup a credit pathway and then add a pathway record for our user
-        self.pathway = PathwayFactory(site=self.site, programs=[self.program])
+        self.pathway = PathwayFactory(site=self.site, programs=[self.program1])
         UserCreditPathwayFactory(user=self.user, pathway=self.pathway, status=UserCreditPathwayStatus.SENT)
         # create a shared program cert record for our user
         self.shared_program_cert_record = ProgramCertRecordFactory(
-            uuid=self.program.uuid, program=self.program, user=self.user
+            uuid=self.program1.uuid, program=self.program1, user=self.user
         )
 
     def _assert_results(self, expected_result, result):
@@ -122,7 +171,7 @@ class ApiTests(SiteMixin, TestCase):
         Test that verifies the functionality of the `_does_awarded_program_cert_exist_for_user` utility function when a
         certificate exists for the user.
         """
-        result = _does_awarded_program_cert_exist_for_user(self.program, self.user)
+        result = _does_awarded_program_cert_exist_for_user(self.program1, self.user)
         assert result is True
 
     def test_does_awarded_program_cert_exist_for_user_no_cert(self):
@@ -130,12 +179,12 @@ class ApiTests(SiteMixin, TestCase):
         Test that verifies the functionality of the `_does_awarded_program_cert_exist_for_user` utility function when a
         certificate exists for the user.
         """
-        self.program_certificate_credential.revoke()
+        self.program_credential.revoke()
 
-        result = _does_awarded_program_cert_exist_for_user(self.program, self.user)
+        result = _does_awarded_program_cert_exist_for_user(self.program1, self.user)
         assert result is False
 
-    def test__get_transformed_learner_data(self):
+    def test_get_transformed_learner_data(self):
         """
         Test that verifies the functionality of the `_get_transformed_learner_data` utility function.
         """
@@ -155,16 +204,16 @@ class ApiTests(SiteMixin, TestCase):
         last_updated = datetime.datetime.now()
 
         expected_result = {
-            "name": self.program.title,
-            "type": slugify(self.program.type),
-            "type_name": self.program.type,
+            "name": self.program1.title,
+            "type": slugify(self.program1.type),
+            "type_name": self.program1.type,
             "completed": True,
             "empty": True,
             "last_updated": last_updated.isoformat(),
-            "school": ", ".join(self.program.authoring_organizations.values_list("name", flat=True)),
+            "school": ", ".join(self.program1.authoring_organizations.values_list("name", flat=True)),
         }
 
-        result = _get_transformed_program_data(self.program, self.user, {}, last_updated)
+        result = _get_transformed_program_data(self.program1, self.user, {}, last_updated)
         self._assert_results(expected_result, result)
 
     def test_get_transformed_pathway_data(self):
@@ -179,37 +228,431 @@ class ApiTests(SiteMixin, TestCase):
             "pathway_type": self.pathway.pathway_type,
         }
 
-        result = _get_transformed_pathway_data(self.program, self.user)
+        result = _get_transformed_pathway_data(self.program1, self.user)
         self._assert_results(expected_result, result[0])
 
     def test_get_transformed_grade_data(self):
         """
-        Test that verifies the functionality of the `_get_transformed_grade_data` utility function.
+        Test that verifies the functionality of the `_get_transformed_grade_data` utility function. In this scenario we
+        have one program associated with two courses, across three course runs. The test verifies that the grade and
+        dates associated with the learner's achievements are what we would expect.
         """
-        expected_issue_date = get_credential_dates(self.course_certificiate_credentials[1], False)
-        expected_result = {
-            "name": self.course_runs[1].title,
-            "school": ",".join(self.course.owners.values_list("name", flat=True)),
-            "attempts": 2,
-            "course_id": self.course_runs[1].key,
-            "issue_date": expected_issue_date.isoformat(),
-            "percent_grade": 1.0,
-            "letter_grade": "A",
+        expected_issue_date_course1 = get_credential_dates(self.course_credential_course1_courserunB, False)
+        expected_issue_date_course2 = get_credential_dates(self.course_credential_course2_courserunA, False)
+        expected_result = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 2,
+                "course_id": self.course1_courserunB.key,
+                "issue_date": expected_issue_date_course1.isoformat(),
+                "percent_grade": 1.0,
+                "letter_grade": "A",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course2_courserunA.key,
+                "issue_date": expected_issue_date_course2.isoformat(),
+                "percent_grade": 0.85,
+                "letter_grade": "B",
+            },
+        ]
+        expected_highest_attempt_dict = {
+            self.course1: self.course1_courserunB_grade,
+            self.course2: self.course2_courserunA_grade,
         }
 
-        expected_highest_attempt_dict = {self.course: self.grade_high}
-
-        result, highest_attempt_dict, last_updated = _get_transformed_grade_data(self.program, self.user)
-        self._assert_results(expected_result, result[0])
+        result, highest_attempt_dict, last_updated = _get_transformed_grade_data(self.program1, self.user)
+        self._assert_results(expected_result[0], result[0])
+        self._assert_results(expected_result[1], result[1])
         self._assert_results(expected_highest_attempt_dict, highest_attempt_dict)
-        assert float(highest_attempt_dict.get(self.course).percent_grade) == self.grade_high.percent_grade
-        assert expected_issue_date == last_updated
+        assert expected_issue_date_course2 == last_updated
+
+    def test_get_transformed_grade_data_has_credential_missing_grade(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_data_data` utility function. If the learner has
+        earned a course credential in a course, but there is no grade information available, we should still populate
+        some data about the credential in the returned data. This is import so that the Learner Record MFE can
+        accurately render data about the learner's achievements in their programs.
+        """
+        # delete the grade record for the learner in "course2"
+        self.course2_courserunA_grade.delete()
+
+        expected_issue_date_course1 = get_credential_dates(self.course_credential_course1_courserunB, False)
+        expected_issue_date_course2 = get_credential_dates(self.course_credential_course2_courserunA, False)
+        expected_result = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 2,
+                "course_id": self.course1_courserunB.key,
+                "issue_date": expected_issue_date_course1.isoformat(),
+                "percent_grade": 1.0,
+                "letter_grade": "A",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": "",
+                "course_id": self.course2_courserunA.key,
+                "issue_date": expected_issue_date_course2.isoformat(),
+                "percent_grade": "",
+                "letter_grade": "",
+            },
+        ]
+        expected_highest_attempt_dict = {
+            self.course1: self.course1_courserunB_grade,
+        }
+
+        result, highest_attempt_dict, last_updated = _get_transformed_grade_data(self.program1, self.user)
+        self._assert_results(expected_result[0], result[0])
+        self._assert_results(expected_result[1], result[1])
+        self._assert_results(expected_highest_attempt_dict, highest_attempt_dict)
+        # in this case, because of how the logic currently is implemented, we should expect the "last updated" date to
+        # be associated with available grades
+        assert expected_issue_date_course1 == last_updated
+
+    def test_get_transformed_grade_data_no_progress(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_grade_data` utility function. If the learner has made
+        no progress in any course of a program, we should return expect data sets.
+        """
+        # "remove" progress in the learner's courses by deleting our credential and grade records
+        self.course_credential_course1_courserunA.delete()
+        self.course_credential_course1_courserunB.delete()
+        self.course_credential_course2_courserunA.delete()
+        self.course_credential_course3_courserunA.delete()
+        self.course1_courserunA_grade.delete()
+        self.course1_courserunB_grade.delete()
+        self.course2_courserunA_grade.delete()
+        self.course3_courserunA_grade.delete()
+
+        expected_result = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": "",
+                "course_id": "",
+                "issue_date": "",
+                "percent_grade": "",
+                "letter_grade": "",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": "",
+                "course_id": "",
+                "issue_date": "",
+                "percent_grade": "",
+                "letter_grade": "",
+            },
+        ]
+
+        result, highest_attempt_dict, _ = _get_transformed_grade_data(self.program1, self.user)
+        self._assert_results(expected_result[0], result[0])
+        self._assert_results(expected_result[1], result[1])
+        self._assert_results({}, highest_attempt_dict)
+
+    def test_get_transformed_grade_data_no_grade_no_credential(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_grade_data` utility function. If there is no grade
+        nor a credential associated with a learner in a course/course-run of a program, we should include a default
+        result with mostly empty fields.
+        """
+        # delete grade and course credential for learner in "course2"
+        self.course2_courserunA_grade.delete()
+        self.course_credential_course2_courserunA.delete()
+
+        expected_issue_date_course1 = get_credential_dates(self.course_credential_course1_courserunB, False)
+        expected_result = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 2,
+                "course_id": self.course1_courserunB.key,
+                "issue_date": expected_issue_date_course1.isoformat(),
+                "percent_grade": 1.0,
+                "letter_grade": "A",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": "",
+                "course_id": "",
+                "issue_date": "",
+                "percent_grade": "",
+                "letter_grade": "",
+            },
+        ]
+        expected_highest_attempt_dict = {
+            self.course1: self.course1_courserunB_grade,
+        }
+
+        result, highest_attempt_dict, last_updated = _get_transformed_grade_data(self.program1, self.user)
+        self._assert_results(expected_result[0], result[0])
+        self._assert_results(expected_result[1], result[1])
+        self._assert_results(expected_highest_attempt_dict, highest_attempt_dict)
+        assert expected_issue_date_course1 == last_updated
+
+    def test_get_transformed_grade_data_earned_credential_with_visible_date(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_grade_data` utility function. If a course credential
+        is associated with a visible date that is set in the future, then it should not be included as part of the
+        results. In this test scenario, we add a "visible date" attribute to the learner's (course) credential instance
+        in "course1_courserun2", and then verify the data that is returned by this function.
+        """
+        UserCredentialAttributeFactory(
+            user_credential=self.course_credential_course1_courserunB,
+            name="visible_date",
+            value="9999-01-01T01:01:01Z",
+        )
+
+        expected_issue_date_course1 = get_credential_dates(self.course_credential_course1_courserunA, False)
+        expected_issue_date_course2 = get_credential_dates(self.course_credential_course2_courserunA, False)
+        expected_result = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course1_courserunA.key,
+                "issue_date": expected_issue_date_course1.isoformat(),
+                "percent_grade": 0.75,
+                "letter_grade": "C",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course2_courserunA.key,
+                "issue_date": expected_issue_date_course2.isoformat(),
+                "percent_grade": 0.85,
+                "letter_grade": "B",
+            },
+        ]
+        expected_highest_attempt_dict = {
+            self.course1: self.course1_courserunA_grade,
+            self.course2: self.course2_courserunA_grade,
+        }
+
+        result, highest_attempt_dict, last_updated = _get_transformed_grade_data(self.program1, self.user)
+        self._assert_results(expected_result[0], result[0])
+        self._assert_results(expected_result[1], result[1])
+        self._assert_results(expected_highest_attempt_dict, highest_attempt_dict)
+        assert expected_issue_date_course2 == last_updated
+
+    @override_waffle_switch(settings.USE_CERTIFICATE_AVAILABLE_DATE, active=True)
+    def test_get_transformed_grade_data_earned_credential_with_certificate_available_date(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_grade_data` utility function. If a course credential
+        is associated with a certificate availability date that is set in the future, then it should not be included as
+        part of the results. In this test scenario, we add a certificate available date to the course certificate
+        associated with the "course1_courserun2" course run and then verify the data that is returned by the function.
+        """
+        self.course_cert_course1_courserunB.certificate_available_date = "9999-05-11T03:14:01Z"
+        self.course_cert_course1_courserunB.save()
+
+        expected_issue_date_course1 = get_credential_dates(self.course_credential_course1_courserunA, False)
+        expected_issue_date_course2 = get_credential_dates(self.course_credential_course2_courserunA, False)
+        expected_result = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course1_courserunA.key,
+                "issue_date": expected_issue_date_course1.isoformat(),
+                "percent_grade": 0.75,
+                "letter_grade": "C",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course2_courserunA.key,
+                "issue_date": expected_issue_date_course2.isoformat(),
+                "percent_grade": 0.85,
+                "letter_grade": "B",
+            },
+        ]
+        expected_highest_attempt_dict = {
+            self.course1: self.course1_courserunA_grade,
+            self.course2: self.course2_courserunA_grade,
+        }
+
+        result, highest_attempt_dict, last_updated = _get_transformed_grade_data(self.program1, self.user)
+        self._assert_results(expected_result[0], result[0])
+        self._assert_results(expected_result[1], result[1])
+        self._assert_results(expected_highest_attempt_dict, highest_attempt_dict)
+        assert expected_issue_date_course2 == last_updated
+
+    def test_get_transformed_grade_data_program_with_excluded_course_run(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_grade_data` utility function. It is possible for two
+        unique programs to share a subset of courses and course runs between them. The Discovery service allows us to
+        explicitly exclude specific course runs from a program.
+
+        This test ensures the functionality of the data presented in the Learner Record MFE, verifying that we don't
+        display course data to a learner if a course run has been explicitly excluded from a program.
+        """
+        expected_issue_date_course1_courserun1 = get_credential_dates(self.course_credential_course1_courserunA, False)
+        expected_issue_date_course1_courserun2 = get_credential_dates(self.course_credential_course1_courserunB, False)
+        expected_issue_date_course2 = get_credential_dates(self.course_credential_course2_courserunA, False)
+        expected_issue_date_course3 = get_credential_dates(self.course_credential_course3_courserunA, False)
+        expected_results_program1 = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 2,
+                "course_id": self.course1_courserunB.key,
+                "issue_date": expected_issue_date_course1_courserun2.isoformat(),
+                "percent_grade": 1.0,
+                "letter_grade": "A",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course2_courserunA.key,
+                "issue_date": expected_issue_date_course2.isoformat(),
+                "percent_grade": 0.85,
+                "letter_grade": "B",
+            },
+        ]
+        expected_results_program2 = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course1_courserunA.key,
+                "issue_date": expected_issue_date_course1_courserun1.isoformat(),
+                "percent_grade": 0.75,
+                "letter_grade": "C",
+            },
+            {
+                "name": self.course3.title,
+                "school": ",".join(self.course3.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course3_courserunA.key,
+                "issue_date": expected_issue_date_course3.isoformat(),
+                "percent_grade": 0.91,
+                "letter_grade": "A",
+            },
+        ]
+        expected_highest_attempt_dict_program1 = {
+            self.course1: self.course1_courserunB_grade,
+            self.course2: self.course2_courserunA_grade,
+        }
+        expected_highest_attempt_dict_program2 = {
+            self.course1: self.course1_courserunA_grade,
+            self.course3: self.course3_courserunA_grade,
+        }
+
+        result_prog1, highest_attempt_dict_prog1, last_updated_prog1 = _get_transformed_grade_data(
+            self.program1, self.user
+        )
+        result_prog2, highest_attempt_dict_prog2, last_updated_prog2 = _get_transformed_grade_data(
+            self.program2, self.user
+        )
+        # verify results of "program1"
+        self._assert_results(expected_results_program1[0], result_prog1[0])
+        self._assert_results(expected_results_program1[1], result_prog1[1])
+        self._assert_results(expected_highest_attempt_dict_program1, highest_attempt_dict_prog1)
+        assert expected_issue_date_course2 == last_updated_prog1
+        # verify results of "program2"
+        self._assert_results(expected_results_program2[0], result_prog2[0])
+        self._assert_results(expected_results_program2[1], result_prog2[1])
+        self._assert_results(expected_highest_attempt_dict_program2, highest_attempt_dict_prog2)
+        assert expected_issue_date_course3 == last_updated_prog2
+
+    def test_get_transformed_grade_data_program_with_excluded_course_run_no_grade(self):
+        """
+        A test that verifies an edge case of the `_get_transformed_grade_data` utility function. It is possible for two
+        unique programs to share a subset of courses and course runs between them. The Discovery service allows us to
+        explicitly exclude specific course runs from a program.
+
+        This test ensures the functionality of the data presented in the Learner Record MFE, verifying that we don't
+        display course data to a learner if a course run has been explicitly excluded from a program.
+
+        This is an additional edge case to the previous unit test where grade data is missing, but we still want to
+        ensure the (course) credential data is returned.
+        """
+        self.course3_courserunA_grade.delete()
+
+        expected_issue_date_course1_courserun1 = get_credential_dates(self.course_credential_course1_courserunA, False)
+        expected_issue_date_course1_courserun2 = get_credential_dates(self.course_credential_course1_courserunB, False)
+        expected_issue_date_course2 = get_credential_dates(self.course_credential_course2_courserunA, False)
+        expected_issue_date_course3 = get_credential_dates(self.course_credential_course3_courserunA, False)
+        expected_results_program1 = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 2,
+                "course_id": self.course1_courserunB.key,
+                "issue_date": expected_issue_date_course1_courserun2.isoformat(),
+                "percent_grade": 1.0,
+                "letter_grade": "A",
+            },
+            {
+                "name": self.course2.title,
+                "school": ",".join(self.course2.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course2_courserunA.key,
+                "issue_date": expected_issue_date_course2.isoformat(),
+                "percent_grade": 0.85,
+                "letter_grade": "B",
+            },
+        ]
+        expected_results_program2 = [
+            {
+                "name": self.course1.title,
+                "school": ",".join(self.course1.owners.values_list("name", flat=True)),
+                "attempts": 1,
+                "course_id": self.course1_courserunA.key,
+                "issue_date": expected_issue_date_course1_courserun1.isoformat(),
+                "percent_grade": 0.75,
+                "letter_grade": "C",
+            },
+            {
+                "name": self.course3.title,
+                "school": ",".join(self.course3.owners.values_list("name", flat=True)),
+                "attempts": "",
+                "course_id": self.course3_courserunA.key,
+                "issue_date": expected_issue_date_course3.isoformat(),
+                "percent_grade": "",
+                "letter_grade": "",
+            },
+        ]
+        expected_highest_attempt_dict_program1 = {
+            self.course1: self.course1_courserunB_grade,
+            self.course2: self.course2_courserunA_grade,
+        }
+        expected_highest_attempt_dict_program2 = {
+            self.course1: self.course1_courserunA_grade,
+        }
+
+        result_prog1, highest_attempt_dict_prog1, last_updated_prog1 = _get_transformed_grade_data(
+            self.program1, self.user
+        )
+        result_prog2, highest_attempt_dict_prog2, last_updated_prog2 = _get_transformed_grade_data(
+            self.program2, self.user
+        )
+        # verify results of "program1"
+        self._assert_results(expected_results_program1[0], result_prog1[0])
+        self._assert_results(expected_results_program1[1], result_prog1[1])
+        self._assert_results(expected_highest_attempt_dict_program1, highest_attempt_dict_prog1)
+        assert expected_issue_date_course2 == last_updated_prog1
+        # verify results of "program2"
+        self._assert_results(expected_results_program2[0], result_prog2[0])
+        self._assert_results(expected_results_program2[1], result_prog2[1])
+        self._assert_results(expected_highest_attempt_dict_program2, highest_attempt_dict_prog2)
+        assert expected_issue_date_course1_courserun1 == last_updated_prog2
 
     def test_get_shared_program_cert_record_data(self):
         """
         Test that verifies the functionality of the `_get_shared_program_cert_record_data` utility function.
         """
-        result = _get_shared_program_cert_record_data(self.program, self.user)
+        result = _get_shared_program_cert_record_data(self.program1, self.user)
         assert result == str(self.shared_program_cert_record.uuid.hex)
 
     def test_get_shared_program_cert_record_data_record_dne(self):
@@ -219,5 +662,5 @@ class ApiTests(SiteMixin, TestCase):
         """
         self.shared_program_cert_record.delete()
 
-        result = _get_shared_program_cert_record_data(self.program, self.user)
+        result = _get_shared_program_cert_record_data(self.program1, self.user)
         assert result is None


### PR DESCRIPTION
[APER-2994]

There are well documented communication issues between the LMS and Credentials systems. There are times that Credentials will just miss a grade update from the LMS. The grades stored in Credentials are used to render a learner's progress in their courses through the Learner Record UI.

This PR changes the behavior of the API that feeds data to the Learner Record MFE (program record page) and the Support Tools.

Previously, when rendering the program record page, if there are no grades available for a course (that is part of a program) we would show the course credential as "unearned".

This has caused a lot of confusion for our learners, as a missing grade in Credentials does not mean they haven't earned the certificate. In fact, most of the time, the learner has been able to view and share their course certificate and they are confused as to why it shows as "unearned" on their program record(s).

Now, if the system is aware of an earned Credential, we will populate the issue_date field (which the frontend uses to determine if a certificate is earned or not). This way we can reflect the learner record as accurately as possible for a learner.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
