### PR TITLE
feat:  bulk learner cert status and point

### DIFF
--- a/credentials/apps/credentials/rest_api/v1/tests/test_views.py
+++ b/credentials/apps/credentials/rest_api/v1/tests/test_views.py
@@ -16,6 +16,7 @@ from credentials.apps.records.tests.factories import UserGradeFactory
 
 
 if TYPE_CHECKING:
+    from credentials.apps.core.models import User
     from credentials.apps.credentials.models import CourseCertificate, CourseRun
 
 
@@ -186,6 +187,203 @@ class LearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
     def test_auth(self):
         """Verify the endpoint does not works except with the service worker or admin"""
         data, expected_response = self.create_credential()  # pylint: disable=unused-variable
+
+        # Test non-authenticated
+        random_user = UserFactory()
+        response = self.call_api(random_user, data)
+        self.assertEqual(response.status_code, 403)
+
+        self.authenticate_user(random_user)
+        response = self.call_api(random_user, data)
+        self.assertEqual(response.status_code, 403)
+
+
+@ddt.ddt
+@mock.patch("django.conf.settings.LEARNER_STATUS_WORKER", "test_learner_status_service_worker")
+class BulkLearnerStatusViewTests(JwtMixin, SiteMixin, APITestCase):
+    status_path = reverse("credentials_api:v1:bulk_learner_cert_status")
+
+    SERVICE_USERNAME = "test_learner_status_service_worker"
+
+    def setUp(self):
+        super().setUp()
+        self.user1 = UserFactory(username=self.SERVICE_USERNAME)
+        self.user2 = UserFactory(username="test_user_2")
+
+    def tearDown(self):
+        super().tearDown()
+        self.client.logout()
+
+    def authenticate_user(self, user):
+        """Login as the given user."""
+        self.client.logout()
+        self.client.login(username=user.username, password=USER_PASSWORD)
+
+    def build_jwt_headers(self, user):
+        """
+        Helper function for creating headers for the JWT authentication.
+        Cloned and owned from elsewhere in the codebase, this should
+        be part of a utility somewhere.
+        """
+        jwt_payload = self.default_payload(user)
+        token = self.generate_token(jwt_payload)
+        headers = {"HTTP_AUTHORIZATION": "JWT " + token}
+        return headers
+
+    def call_api(self, user, data):
+        """
+        Helper function to call API with data
+        """
+        data = json.dumps(data)
+        headers = self.build_jwt_headers(user)
+        return self.client.post(self.status_path, data, **headers, content_type=JSON_CONTENT_TYPE)
+
+    def create_test_data(
+        self,
+        user: "User",
+        id_type: str = IdType.username,
+        cred_id_type: str = CredIdType.course_uuid,
+        grade_type: str = GradeType.grade,
+    ):
+        """
+        Create the payload for a request (user, course run, cred) and also the expected response.
+        """
+        course_run: "CourseRun" = CourseRunFactory.create()
+        credential: "CourseCertificate" = CourseCertificateFactory.create(
+            course_id=course_run.course.key, site=self.site, course_run=course_run
+        )
+        user_credential = UserCredentialFactory(
+            credential=credential, credential__site=self.site, username=user.username
+        )
+        if grade_type == GradeType.grade:
+            expected_grade = UserGradeFactory(username=user.username, course_run=course_run)
+
+        data = {}
+        if id_type == IdType.lms_user_id:
+            data["lms_user_id"] = user.lms_user_id
+        else:
+            data["username"] = user.username
+
+        if cred_id_type == CredIdType.course_run_uuid:
+            data["course_runs"] = [str(user_credential.credential.course_run.uuid)]
+        elif cred_id_type == CredIdType.course_run_key:
+            data["course_runs"] = [str(user_credential.credential.course_run.key)]
+        else:
+            data["courses"] = [str(user_credential.credential.course_run.course.uuid)]
+
+        expected_response = {
+            "lms_user_id": user.lms_user_id,
+            "username": user.username,
+            "status": [
+                {
+                    "course_uuid": str(course_run.course.uuid),
+                    "course_run": {"uuid": str(course_run.uuid), "key": course_run.key},
+                    "status": "awarded",
+                    "type": "honor",
+                    "certificate_available_date": None,
+                    "grade": None,
+                }
+            ],
+        }
+
+        if grade_type == GradeType.grade:
+            expected_response["status"][0]["grade"] = {
+                "letter_grade": expected_grade.letter_grade,
+                "percent_grade": expected_grade.percent_grade,
+                "verified": expected_grade.verified,
+            }
+
+        return data, expected_response
+
+    @ddt.data(
+        (IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade),
+        (IdType.lms_user_id, CredIdType.course_run_key, GradeType.no_grade),
+        (IdType.username, CredIdType.course_uuid, GradeType.grade),
+        (IdType.username, CredIdType.course_run_key, GradeType.grade),
+    )
+    @ddt.unpack
+    def test_post_positive(self, id_type, cred_type, grade_type):
+        """
+        Test the iterations of id and course-run vs course
+        """
+        data1, expected_response1 = self.create_test_data(self.user1, id_type, cred_type, grade_type)
+        data2, expected_response2 = self.create_test_data(self.user2, id_type, cred_type, grade_type)
+        data = [data1, data2]
+        expected_response = [expected_response1, expected_response2]
+
+        response = self.call_api(self.user1, data)
+        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+
+        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+    @ddt.data(
+        (IdType.lms_user_id, CredIdType.course_run_uuid, GradeType.grade),
+        (IdType.username, CredIdType.course_run_uuid, GradeType.grade),
+    )
+    @ddt.unpack
+    def test_unknown_user_returns_empty_status(self, id_type, cred_type, grade_type):
+        """An unknown username or lms_user_id should return valid with an empty status.
+
+        Uses the create_test_data method, even though it's not really using the
+        credential, in order to avoid replicating the logic of creating the data
+        payload."""
+        data1, expected_response1 = self.create_test_data(self.user1, id_type, cred_type, grade_type)
+        data2, expected_response2 = self.create_test_data(self.user2, id_type, cred_type, grade_type)
+        if id_type == IdType.lms_user_id:
+            data1["lms_user_id"] = 666
+            data1["username"] = None
+        else:
+            data1["lms_user_id"] = None
+            data1["username"] = "i_am_a_big_faker"
+
+        expected_response1 = {
+            "lms_user_id": data1["lms_user_id"],
+            "username": data1["username"],
+            "status": [],
+        }
+
+        data = [data1, data2]
+        expected_response = [expected_response1, expected_response2]
+
+        response = self.call_api(self.user1, data)
+
+        self.assertEqual(response.status_code, 200, msg="Did not get back expected response code")
+        self.assertEqual(response.data, expected_response, msg="Unexpected value returned from query")
+
+    def test_lms_and_username(self):
+        """Call should fail because only one of username or lms id can be provided."""
+        data1, expected_response1 = self.create_test_data(self.user1)  # pylint: disable=unused-variable
+        data2, expected_response2 = self.create_test_data(self.user2)  # pylint: disable=unused-variable
+        data1["lms_user_id"] = self.user1.lms_user_id
+        data = [data1, data2]
+
+        response = self.call_api(self.user1, data)
+        self.assertEqual(response.status_code, 400, msg="API should not allow lms_id AND username")
+
+    def test_user_no_credentials(self):
+        """Query for an existing course, but user has no credentials that match query"""
+
+        # Generate credentials, including one for the login user, so there is a legit course
+        data1, expected_response1 = self.create_test_data(self.user1)  # pylint: disable=unused-variable
+        data2, expected_response2 = self.create_test_data(self.user2)  # pylint: disable=unused-variable
+
+        # Slide in a different username with no courses
+        uncredentialled_user = UserFactory()
+        data1["username"] = uncredentialled_user.username
+
+        data = [data1, data2]
+
+        response = self.call_api(self.user1, data)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data[0]["username"], uncredentialled_user.username)
+        self.assertEqual(len(response.data[0]["status"]), 0)
+
+    def test_auth(self):
+        """Verify the endpoint does not work except with the service worker or admin"""
+        data1, expected_response1 = self.create_test_data(self.user1)  # pylint: disable=unused-variable
+        data2, expected_response2 = self.create_test_data(self.user2)  # pylint: disable=unused-variable
+
+        data = [data1, data2]
 
         # Test non-authenticated
         random_user = UserFactory()

--- a/credentials/apps/credentials/rest_api/v1/urls.py
+++ b/credentials/apps/credentials/rest_api/v1/urls.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from credentials.apps.credentials.rest_api.v1.views import LearnerCertificateStatusView
+from credentials.apps.credentials.rest_api.v1.views import (
+    BulkLearnerCertificateStatusView,
+    LearnerCertificateStatusView,
+)
 
 
 urlpatterns = [
@@ -8,5 +11,10 @@ urlpatterns = [
         "learner_cert_status/",
         LearnerCertificateStatusView.as_view(),
         name="learner_cert_status",
-    )
+    ),
+    path(
+        "bulk_learner_cert_status/",
+        BulkLearnerCertificateStatusView.as_view(),
+        name="bulk_learner_cert_status",
+    ),
 ]

--- a/credentials/apps/credentials/rest_api/v1/views.py
+++ b/credentials/apps/credentials/rest_api/v1/views.py
@@ -165,10 +165,13 @@ class BulkLearnerCertificateStatusView(APIView):
             * The `courses` list should contain a list of course UUIDs.
             * The `course_runs` list should contain a list of course run keys.
 
-        If the `username` or `lms_user_id` has not earned any certificates, the `status` object will be empty for that user.
+        If the `username` or `lms_user_id` has not earned any certificates, the `status` object will be
+        empty for that user.
 
-        If any individual object in the list describing a user/course is invalid and cannot be resolved to a single learner's identity (e.g. does
-        not include exactly one lms_user_id or username), that object will be skipped and there will be no corresponding entry in the return list.
+        If any individual object in the list describing a user/course is invalid
+        and cannot be resolved to a single learner's identity (e.g. does not
+        include exactly one lms_user_id or username), that object will be
+        skipped and there will be no corresponding entry in the return list.
         """
         request_list = request.data  # type: Optional[List[Dict]]
         response_list = []

--- a/credentials/apps/credentials/rest_api/v1/views.py
+++ b/credentials/apps/credentials/rest_api/v1/views.py
@@ -1,7 +1,7 @@
 import logging
-from typing import Optional
+from typing import Dict, List, Optional
 
-from django.contrib.auth import get_user_model
+from django.core.exceptions import BadRequest
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
@@ -10,12 +10,82 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from credentials.apps.core.api import get_user_by_username
 from credentials.apps.credentials.rest_api.v1.permissions import CanGetLearnerStatus
-from credentials.apps.records.api import get_learner_course_run_status
+from credentials.apps.records.api import single_learner_cert_status
 
 
 log = logging.getLogger(__name__)
+
+
+lms_user_id_schema = openapi.Schema(type=openapi.TYPE_INTEGER, description="lms_user_id")
+
+username_schema = openapi.Schema(type=openapi.TYPE_STRING, description="username")
+
+per_course_grade_schema = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "letter_grade": openapi.Schema(type=openapi.TYPE_STRING),
+        "percent_grade": openapi.Schema(type=openapi.FORMAT_DECIMAL),
+        "verified": openapi.Schema(type=openapi.TYPE_BOOLEAN),
+    },
+)
+course_run_object_schema = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "uuid": openapi.Schema(type=openapi.TYPE_STRING),
+        "key": openapi.Schema(type=openapi.TYPE_STRING),
+        "status": openapi.Schema(type=openapi.TYPE_STRING),
+        "type": openapi.Schema(type=openapi.TYPE_STRING),
+        "certificate_available_date": openapi.Schema(type=openapi.FORMAT_DATE),
+        "grade": per_course_grade_schema,
+    },
+)
+per_course_status_schema = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "course_uuid": openapi.TYPE_STRING,
+        "course_run": course_run_object_schema,
+    },
+)
+
+learner_cert_status_request_schema = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "lms_user_id": lms_user_id_schema,
+        "username": username_schema,
+        "courses": openapi.Schema(
+            type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING), description="array of strings"
+        ),
+        "course_runs": openapi.Schema(
+            type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING), description="array of strings"
+        ),
+    },
+)
+
+
+bulk_learner_cert_status_request_schema = openapi.Schema(
+    type=openapi.TYPE_ARRAY,
+    items=openapi.Items(type=learner_cert_status_request_schema),
+    description="array of learner_cert_status_request objects",
+)
+
+learner_cert_status_return_schema = openapi.Schema(
+    type=openapi.TYPE_OBJECT,
+    properties={
+        "lms_user_id": lms_user_id_schema,
+        "username": username_schema,
+        "status": openapi.Schema(
+            type=openapi.TYPE_ARRAY,
+            items=course_run_object_schema,
+        ),
+    },
+)
+
+bulk_learner_cert_status_return_schema = openapi.Schema(
+    type=openapi.TYPE_ARRAY,
+    items=openapi.Items(type=learner_cert_status_return_schema),
+    description="array of learner_cert_status_return objects",
+)
 
 
 class LearnerCertificateStatusView(APIView):
@@ -28,64 +98,6 @@ class LearnerCertificateStatusView(APIView):
         permissions.IsAuthenticated,
         CanGetLearnerStatus,
     )
-
-    lms_user_id_schema = openapi.Schema(type=openapi.TYPE_INTEGER, description="lms_user_id")
-
-    username_schema = openapi.Schema(type=openapi.TYPE_STRING, description="username")
-
-    per_course_grade_schema = openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            "letter_grade": openapi.Schema(type=openapi.TYPE_STRING),
-            "percent_grade": openapi.Schema(type=openapi.FORMAT_DECIMAL),
-            "verified": openapi.Schema(type=openapi.TYPE_BOOLEAN),
-        },
-    )
-    course_run_object_schema = openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            "uuid": openapi.Schema(type=openapi.TYPE_STRING),
-            "key": openapi.Schema(type=openapi.TYPE_STRING),
-            "status": openapi.Schema(type=openapi.TYPE_STRING),
-            "type": openapi.Schema(type=openapi.TYPE_STRING),
-            "certificate_available_date": openapi.Schema(type=openapi.FORMAT_DATE),
-            "grade": per_course_grade_schema,
-        },
-    )
-    per_course_status_schema = openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            "course_uuid": openapi.TYPE_STRING,
-            "course_run": course_run_object_schema,
-        },
-    )
-
-    learner_cert_status_request_schema = openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            "lms_user_id": lms_user_id_schema,
-            "username": username_schema,
-            "courses": openapi.Schema(
-                type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING), description="array of strings"
-            ),
-            "course_runs": openapi.Schema(
-                type=openapi.TYPE_ARRAY, items=openapi.Items(type=openapi.TYPE_STRING), description="array of strings"
-            ),
-        },
-    )
-
-    learner_cert_status_return_schema = openapi.Schema(
-        type=openapi.TYPE_OBJECT,
-        properties={
-            "lms_user_id": lms_user_id_schema,
-            "username": username_schema,
-            "status": openapi.Schema(
-                type=openapi.TYPE_ARRAY,
-                items=course_run_object_schema,
-            ),
-        },
-    )
-
     learner_cert_status_responses = {
         status.HTTP_200_OK: learner_cert_status_return_schema,
     }
@@ -109,32 +121,67 @@ class LearnerCertificateStatusView(APIView):
         """
         lms_user_id = request.data.get("lms_user_id")  # type: Optional[int]
         username = request.data.get("username")  # type: Optional[str]
+        course_ids = request.data.get("courses")  # type: Optional[List[str]]
+        course_runs = request.data.get("course_runs")  # type: Optional[List[str]]
 
-        # only one of username or lms_user_id can be used
-        if (username and lms_user_id) or not (username or lms_user_id):
+        try:
+            return Response(
+                status=status.HTTP_200_OK,
+                data=single_learner_cert_status(lms_user_id, username, course_ids, course_runs),
+            )
+        except BadRequest:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        User = get_user_model()
 
-        try:
-            if username:
-                user = get_user_by_username(username)
-                if user:
-                    lms_user_id = user.lms_user_id
-                else:
-                    raise User.DoesNotExist()
-            else:
-                user = User.objects.get(lms_user_id=lms_user_id)
-                username = user.username
-        except User.DoesNotExist:
-            courses = []
-        else:
-            course_ids = request.data.get("courses")
-            course_runs = request.data.get("course_runs")
-            courses = get_learner_course_run_status(username, course_ids, course_runs)
+
+class BulkLearnerCertificateStatusView(APIView):
+    authentication_classes = (
+        JwtAuthentication,
+        SessionAuthentication,
+    )
+
+    permission_classes = (
+        permissions.IsAuthenticated,
+        CanGetLearnerStatus,
+    )
+    bulk_learner_cert_status_responses = {
+        status.HTTP_200_OK: bulk_learner_cert_status_return_schema,
+    }
+
+    @swagger_auto_schema(
+        request_body=bulk_learner_cert_status_request_schema,
+        responses=bulk_learner_cert_status_responses,
+    )
+    def post(self, request):
+        """Query for earned certificates for a list of users.
+
+        Query for list of user's earned certificates for a list of courses or course runs.
+
+        In each object in the list describing a user/course combination:
+
+        * You must include _exactly one_ of `lms_user_id` or `username`.
+        * You must include at least one of `courses` and `course_runs`, and you may include a mix of both.
+            * The `courses` list should contain a list of course UUIDs.
+            * The `course_runs` list should contain a list of course run keys.
+
+        If the `username` or `lms_user_id` has not earned any certificates, the `status` object will be empty for that user.
+
+        If any individual object in the list describing a user/course is invalid and cannot be resolved to a single learner's identity (e.g. does
+        not include exactly one lms_user_id or username), that object will be skipped and there will be no corresponding entry in the return list.
+        """
+        request_list = request.data  # type: Optional[List[Dict]]
+        response_list = []
+
+        for req in request_list:
+            lms_user_id = req.get("lms_user_id")  # type: Optional[int]
+            username = req.get("username")  # type: Optional[str]
+            course_ids = req.get("courses")  # type: Optional[List[str]]
+            course_runs = req.get("course_runs")  # type: Optional[List[str]]
+
+            response_list.append(single_learner_cert_status(lms_user_id, username, course_ids, course_runs))
 
         return Response(
             status=status.HTTP_200_OK,
-            data={"lms_user_id": lms_user_id, "username": username, "status": courses},
+            data=response_list,
         )

--- a/credentials/apps/records/api.py
+++ b/credentials/apps/records/api.py
@@ -426,9 +426,9 @@ def single_learner_cert_status(
         * The `course_runs` list should contain a list of course run keys.
 
     Returns:
-        A dict of an individuals user's earned certificates for a list of courses or course runs.
+        A dict of an individual user's earned certificates for a list of courses or course runs.
 
-        If the userhas not earned any certificates, the `status` object will be empty.
+        If the user has not earned any certificates, the `status` object will be empty.
 
     Raises:
         BadRequest

--- a/docs/credentials_api.rst
+++ b/docs/credentials_api.rst
@@ -268,3 +268,81 @@ In this example, this user has earned a certificate in only one of the courses r
             }
         ]
     }
+
+Query for multiple learners' earned certificates for specific courses
+--------------------------------------------------------------------------
+
+Query for multiple learners' earned certificates for a list of courses or course runs.
+
+**Note**:
+
+For each requested response:
+
+* You must include `exactly one` of ``lms_user_id`` or ``username``.
+* You must include at least one of ``courses`` and ``course_runs``, and you may include a mix of both.
+    * The ``courses`` list should contain a list of course UUIDs.
+    * The ``course_runs`` list should contain a list of course run keys.
+
+If the ``username`` or ``lms_user_id`` has not earned any certificates, the ``status`` object will be empty.
+
+**Example Request**
+
+.. code-block:: text
+
+    POST api/credentials/v1/bulk_learner_cert_status/
+
+.. code-block:: json
+
+    [
+        {
+            "username": "sample_user",
+            "courses": [
+                "4ad04e84-1512-11ee-be56-0242ac120002",
+                "4ad051fe-1512-11ee-be56-0242ac120002"
+            ],
+            "course_runs": [
+                "course-v1:edX+AA302+2T2023a"
+            ]
+        },
+        {
+            "lms_user_id":  8674309,
+            "courses": [
+                "4ad04e84-1513-11ee-be56-0242ac12000f",
+                "4ad051fe-1513-11ee-be56-0242ac12000f"
+            ],
+            "course_runs": [
+                "course-v1:edX+ZZ302+2T2023a"
+            ]
+        }
+    ]
+
+**Example Response**
+
+In this example, the first user has earned a certificate in only one of the courses requested,  and the second user hasn't earned a certificate at
+all, so there is only one return value.
+
+.. code-block:: json
+
+    [
+        {
+            "lms_user_id": 3,
+            "username": "sample_user",
+            "status": [
+                {
+                "course_uuid": "4ad04e84-1512-11ee-be56-0242ac120002",
+                "course_run": {
+                    "uuid": "4747fefb-6f31-4689-bcfb-8ff32da191f4",
+                    "key": "course-v1:edX+AA302+2T2023a"
+                    },
+                "status": "awarded",
+                "type": "verified",
+                "certificate_available_date": null,
+                "grade": {
+                    "letter_grade": "Pass",
+                    "percent_grade": 1,
+                    "verified": true
+                    }
+                }
+            ]
+        }
+    ]

--- a/docs/credentials_api.rst
+++ b/docs/credentials_api.rst
@@ -283,7 +283,8 @@ For each requested response:
     * The ``courses`` list should contain a list of course UUIDs.
     * The ``course_runs`` list should contain a list of course run keys.
 
-If the ``username`` or ``lms_user_id`` has not earned any certificates, the ``status`` object will be empty.
+If the ``username`` or ``lms_user_id`` has not earned any certificates (or does not exist in the system),
+the ``status`` object will be empty.
 
 **Example Request**
 
@@ -318,8 +319,9 @@ If the ``username`` or ``lms_user_id`` has not earned any certificates, the ``st
 
 **Example Response**
 
-In this example, the first user has earned a certificate in only one of the courses requested,  and the second user hasn't earned a certificate at
-all, so there is only one return value.
+In this example, the first user has earned a certificate in only one of the
+courses requested, and the second user hasn't earned a certificate at all, so
+only one return value contains a populated status block.
 
 .. code-block:: json
 
@@ -344,5 +346,10 @@ all, so there is only one return value.
                     }
                 }
             ]
+        },
+        {
+            "lms_user_id":  8674309,
+            "username": null,
+            "status": []
         }
     ]


### PR DESCRIPTION
Adds a bulk version of the learner_cert_status endpoint, following the pattern we use elsewhere for bulk variants: `bulk_learner_cert_status`.

Extrapolating the logic for a single learner/course combo into the API. Whether that particular structure belonged in api.py or in the specific API view is a matter of art rather than science; it felt like a more generalized function for the Python API rather than something for the view. (Reasonable developers could disagree; the specifics of the structure here are designed around the API view so you could go either way. To me it felt cleaner to leave it in `api.py`.)

This does have some repeated code as a side effect of not wanting to change the contract for the previously-existing endpoint, but it's kept to a minimum..

FIXES: APER-3102

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
