### PR TITLE
feat: allow download of program record even when segment is blocked

### DIFF
--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.test import TestCase
-from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -24,7 +23,7 @@ from credentials.apps.catalog.tests.factories import (
     PathwayFactory,
     ProgramFactory,
 )
-from credentials.apps.core.tests.factories import USER_PASSWORD, SiteConfigurationFactory, UserFactory
+from credentials.apps.core.tests.factories import USER_PASSWORD, UserFactory
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.constants import UUID_PATTERN
 from credentials.apps.credentials.models import UserCredential

--- a/credentials/apps/records/tests/test_views.py
+++ b/credentials/apps/records/tests/test_views.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core import mail
 from django.test import TestCase
+from django.test.client import Client, RequestFactory
 from django.test.utils import override_settings
 from django.urls import reverse
 
@@ -23,7 +24,7 @@ from credentials.apps.catalog.tests.factories import (
     PathwayFactory,
     ProgramFactory,
 )
-from credentials.apps.core.tests.factories import USER_PASSWORD, UserFactory
+from credentials.apps.core.tests.factories import USER_PASSWORD, SiteConfigurationFactory, UserFactory
 from credentials.apps.core.tests.mixins import SiteMixin
 from credentials.apps.credentials.constants import UUID_PATTERN
 from credentials.apps.credentials.models import UserCredential
@@ -289,7 +290,6 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.user = UserFactory(username=self.MOCK_USER_DATA["username"])
-        self.client.login(username=self.user.username, password=USER_PASSWORD)
         self.course = CourseFactory(site=self.site)
         self.course_runs = [CourseRunFactory(course=self.course) for _ in range(3)]
         self.user_grade_low = UserGradeFactory(
@@ -393,6 +393,19 @@ class ProgramRecordCsvViewTests(SiteMixin, TestCase):
         actual = response["Content-Disposition"]
 
         self.assertTrue(re.fullmatch(re_expected, actual))
+
+    def test_without_segment(self):
+        """
+        Verify this works without any Segment connection from the browser, even if there is a segment_key
+        for the site.
+        """
+        self.site_configuration.segment_key = "xyzzy"
+        self.site_configuration.save()
+        response = self.client.get(
+            reverse("records:program_record_csv", kwargs={"uuid": self.program_cert_record.uuid.hex})
+        )
+
+        self.assertEqual(200, response.status_code)
 
 
 class LearnerRecordRedirectionTests(SiteMixin, TestCase):

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -316,10 +316,10 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
                 request.site,
                 platform_name=site_configuration.platform_name,
             )
-        except Exception as e:
+        except Exception:
             log.error(
                 "get_program_record failed for:\n"
-                "   user: {userid}\n"
+                "   user: {user_id}\n"
                 "   program: {program}\n"
                 "   site: {site}\n"
                 "   platform_name: {platform_name}\n".format(
@@ -335,7 +335,7 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
         platform_name = record.get("platform_name", None)  # type: str
         learner = record.get("learner", None)  # type: Dict
         if not (program and platform_name and learner):
-            log.warn("get_program_record failed to find all program record data: {record}".format(record=record))
+            log.info("get_program_record failed to find all program record data: {record}".format(record=record))
             raise Http404
 
         user_metadata = [

--- a/credentials/apps/records/views.py
+++ b/credentials/apps/records/views.py
@@ -319,15 +319,14 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
         except Exception:
             log.error(
                 "get_program_record failed for:\n"
-                "   user: {user_id}\n"
-                "   program: {program}\n"
-                "   site: {site}\n"
-                "   platform_name: {platform_name}\n".format(
-                    user_id=program_cert_record.user.id,
-                    program=program_cert_record.program.uuid,
-                    site=request.site,
-                    platform_name=site_configuration.platform_name,
-                )
+                "   user: %s\n"
+                "   program: %s\n"
+                "   site: %s\n"
+                "   platform_name: %s\n",
+                program_cert_record.user.id,
+                program_cert_record.program.uuid,
+                request.site,
+                site_configuration.platform_name,
             )
             raise
 
@@ -335,7 +334,7 @@ class ProgramRecordCsvView(RecordsEnabledMixin, View):
         platform_name = record.get("platform_name", None)  # type: str
         learner = record.get("learner", None)  # type: Dict
         if not (program and platform_name and learner):
-            log.info("get_program_record failed to find all program record data: {record}".format(record=record))
+            log.info("get_program_record failed to find all program record data: %s", record)
             raise Http404
 
         user_metadata = [


### PR DESCRIPTION
we were assuming that segment was always being permitted from the browser side, but segment is blocked by every single privacy built in, including strict tracking protections in the browser. Allow download of the record in that case.

FIXES: APER-3164

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
