### PR TITLE
feat: unpin social auth django

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -294,6 +294,7 @@ edx-django-utils==5.10.1
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via
     #   -r requirements/dev.txt
@@ -331,7 +332,7 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/dev.txt
-faker==22.7.0
+faker==23.1.0
     # via
     #   -r requirements/dev.txt
     #   factory-boy
@@ -446,7 +447,7 @@ openedx-atlas==0.6.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-openedx-events==9.4.0
+openedx-events==9.5.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -693,9 +694,8 @@ slumber==0.7.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.4.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-auth-backends

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -136,6 +136,7 @@ edx-django-utils==5.10.1
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via -r requirements/base.in
 edx-event-bus-kafka==5.6.0
@@ -187,7 +188,7 @@ openapi-codec==1.3.2
     # via django-rest-swagger
 openedx-atlas==0.6.0
     # via -r requirements/base.in
-openedx-events==9.4.0
+openedx-events==9.5.0
     # via edx-event-bus-kafka
 packaging==23.2
     # via drf-yasg
@@ -277,9 +278,8 @@ six==1.16.0
     #   python-dateutil
 slumber==0.7.1
     # via edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.4.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   edx-auth-backends
 social-auth-core==4.5.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,7 +18,3 @@ pyyaml<6.0
 # Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
 # APER-2422
 urllib3<2
-
-# social-auth-app-django versions after 5.2.0 has a problematic migration that will cause issues deployments with large
-# `social_auth_usersocialauth` tables
-social-auth-app-django<5.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -217,6 +217,7 @@ edx-django-utils==5.10.1
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via -r requirements/test.txt
 edx-event-bus-kafka==5.6.0
@@ -246,7 +247,7 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==22.7.0
+faker==23.1.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -327,7 +328,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 openedx-atlas==0.6.0
     # via -r requirements/test.txt
-openedx-events==9.4.0
+openedx-events==9.5.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -526,9 +527,8 @@ slumber==0.7.1
     # via
     #   -r requirements/test.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.4.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
 social-auth-core==4.5.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -168,6 +168,7 @@ edx-django-utils==5.10.1
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via -r requirements/base.txt
 edx-event-bus-kafka==5.6.0
@@ -253,7 +254,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 openedx-atlas==0.6.0
     # via -r requirements/base.txt
-openedx-events==9.4.0
+openedx-events==9.5.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -386,9 +387,8 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.4.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.5.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -185,6 +185,7 @@ edx-django-utils==5.10.1
     #   edx-event-bus-kafka
     #   edx-rest-api-client
     #   edx-toggles
+    #   openedx-events
 edx-drf-extensions==10.2.0
     # via -r requirements/base.txt
 edx-event-bus-kafka==5.6.0
@@ -211,7 +212,7 @@ exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==22.7.0
+faker==23.1.0
     # via factory-boy
 fastavro==1.9.3
     # via
@@ -281,7 +282,7 @@ openapi-codec==1.3.2
     #   django-rest-swagger
 openedx-atlas==0.6.0
     # via -r requirements/base.txt
-openedx-events==9.4.0
+openedx-events==9.5.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -452,9 +453,8 @@ slumber==0.7.1
     # via
     #   -r requirements/base.txt
     #   edx-rest-api-client
-social-auth-app-django==5.2.0
+social-auth-app-django==5.4.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-auth-backends
 social-auth-core==4.5.2


### PR DESCRIPTION
* now that we've truncated the old entries in usersocialauth, unpinning this dependency.
* Includes some requirements updates from `make upgrade`

## Important

If maintainers have migration failures on this upgrade, they should run `truncate_social_auth`:

https://github.com/openedx/credentials/blob/master/credentials/apps/core/management/commands/truncate_social_auth.py

This will remove all entries from the `usersocialauth` table that haven't been updated in 90 days, which makes the size of the table tractable for the dependency's migration.

FIXES: APER-3161
