### PR TITLE
feat:  fixing broken CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @edx/edx-aperture
+* @openedx/2U-aperture


### PR DESCRIPTION
we need to use the openedx group for any automated processes to work

FIXES: APER-3249

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
