### PR TITLE
feat:  updating locale file for unsupported language

### DIFF
--- a/credentials/conf/locale/config.yaml
+++ b/credentials/conf/locale/config.yaml
@@ -1,10 +1,5 @@
 # Configuration for i18n workflow.
 
-# This will copy each source language to a new directory at the end of the i18n generate step
-# which allows us to migrate to a new locale code without re-creating the Transifex project.
-edx_lang_map:
-    zh_TW: zh_HANT
-
 locales:
     - en  # English - Source Language
 


### PR DESCRIPTION
* Although the directory for the unsupported language still exists in the code base, the [Makefile  deletes all committed locales](https://github.com/openedx/credentials/blob/781635ddb318312fbb7128252347cbaa0166c076/Makefile#L148-L149) before doing `atlas pull`, and the language in question is not currently pulled:

https://github.com/openedx/credentials/blob/781635ddb318312fbb7128252347cbaa0166c076/Makefile#L148-L149

FIXES: APER-3345

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
