### PR TITLE
fix: pin python-xmlsec to earlier version in mysql8-migrations-check

### DIFF
--- a/.github/workflows/migrations-mysql8-check.yml
+++ b/.github/workflows/migrations-mysql8-check.yml
@@ -52,7 +52,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec xmlsec==1.3.13
 
     - name: Initiate Services
       run: |


### PR DESCRIPTION
`python-xmlsec`'s current version 1.3.14 is causing some issues during the dependency installation stage of `mysql8-migrations-check`. This PR is to pin it to 1.3.13 for the time being until the issue can be resolved. 
https://github.com/xmlsec/python-xmlsec/issues/314

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
