### PR TITLE
feat:  enabling the fb program certificate share

### DIFF
--- a/credentials/apps/catalog/api.py
+++ b/credentials/apps/catalog/api.py
@@ -34,9 +34,7 @@ def get_program_details_by_uuid(uuid, site):
     return _convert_program_to_program_details(program)
 
 
-def _convert_program_to_program_details(
-    program,
-):
+def _convert_program_to_program_details(program: _Program) -> ProgramDetails:
     """
     Converts a Program (model instance) into a ProgramDetails dataclass.
 

--- a/credentials/apps/credentials/models.py
+++ b/credentials/apps/credentials/models.py
@@ -4,6 +4,7 @@ Models for the credentials service.
 
 import logging
 import uuid
+from typing import TYPE_CHECKING
 
 import bleach
 from django.conf import settings
@@ -25,6 +26,10 @@ from credentials.apps.catalog.models import CourseRun, Program
 from credentials.apps.core.utils import _choices
 from credentials.apps.credentials import constants
 from credentials.apps.credentials.exceptions import NoMatchingProgramException
+
+
+if TYPE_CHECKING:
+    from credentials.apps.catalog.data import ProgramDetails
 
 
 log = logging.getLogger(__name__)
@@ -297,7 +302,7 @@ class ProgramCertificate(AbstractCertificate):
         unique_together = (("site", "program_uuid"),)
 
     @cached_property
-    def program_details(self):
+    def program_details(self) -> "ProgramDetails":
         """Returns details about the program associated with this certificate."""
         program_details = get_program_details_by_uuid(uuid=self.program_uuid, site=self.site)
 

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import uuid
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
@@ -29,18 +30,19 @@ class SocialMediaMixin:
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         request = self.request
-        site_configuration = request.site.siteconfiguration
+        self.site_configuration = request.site.siteconfiguration
+        tweet_text = _("I completed a course at {platform_name}. Take a look at my certificate:").format(
+            platform_name=self.site_configuration.platform_name
+        )
+        twitter_url = "https://twitter.com/intent/tweet?text={{ tweet_text|urlencode }}&url={{ share_url|urlencode }}{% if twitter_username %}&via={{ twitter_username }}{% endif %}"
         context.update(
             {
-                "facebook_app_id": site_configuration.facebook_app_id,
-                "twitter_username": site_configuration.twitter_username,
-                "enable_facebook_sharing": site_configuration.enable_facebook_sharing,
-                "enable_linkedin_sharing": site_configuration.enable_linkedin_sharing,
-                "enable_twitter_sharing": site_configuration.enable_twitter_sharing,
+                "twitter_username": self.site_configuration.twitter_username,
+                "enable_facebook_sharing": self.site_configuration.enable_facebook_sharing,
+                "enable_linkedin_sharing": self.site_configuration.enable_linkedin_sharing,
+                "enable_twitter_sharing": self.site_configuration.enable_twitter_sharing,
                 "share_url": request.build_absolute_uri,
-                "tweet_text": _("I completed a course at {platform_name}. Take a look at my certificate:").format(
-                    platform_name=site_configuration.platform_name
-                ),
+                "twitter_url": twitter_url,
             }
         )
         return context
@@ -109,7 +111,7 @@ class RenderCredential(SocialMediaMixin, ThemeViewMixin, TemplateView):
 
         visible_date = self.get_visible_date()
 
-        program_details = user_credential.credential.program_details
+        program_details = user_credential.credential.program_details  # type: ProgramDetails
         organization_names = _get_organizations_list(program_details)
 
         content_language = to_language(user_credential.credential.language)
@@ -123,6 +125,27 @@ class RenderCredential(SocialMediaMixin, ThemeViewMixin, TemplateView):
         if user_data.get("use_verified_name_for_certs"):
             credential_name = user_data["verified_name"]
 
+        # See https://addtoprofile.linkedin.com/ for documentation on parameters
+        # We don't populate the LinkedIn org ID in the catalog app, so use org name.
+        linkedin_params = {
+            "name": program_details.credential_title or program_details.title,
+            "certUrl": self.request.build_absolute_uri(),
+            "certId": user_credential.uuid.hex,
+            "organizationName": org_name_string,
+            "issueYear": visible_date.year,
+            "issueMonth": visible_date.month,
+        }
+        linkedin_url = "https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME&{params}".format(
+            params=urlencode(linkedin_params)
+        )
+        # See https://developers.facebook.com/docs/sharing/reference/share-dialog
+        # for documentation on parameters.
+        facebook_params = {
+            "app_id": self.site_configuration.facebook_app_id,
+            "display": "popup",
+            "href": self.request.build_absolute_uri(),
+        }
+        facebook_url = "https://www.facebook.com/dialog/share?{params}".format(params=urlencode(facebook_params))
         context.update(
             {
                 "user_credential": user_credential,
@@ -137,6 +160,8 @@ class RenderCredential(SocialMediaMixin, ThemeViewMixin, TemplateView):
                 "program_name": program_details.title,
                 "credential_title": program_details.credential_title,
                 "org_name_string": org_name_string,
+                "linkedin_url": linkedin_url,
+                "facebook_url": facebook_url,
             }
         )
         if program_details.hours_of_effort:

--- a/credentials/apps/credentials/views.py
+++ b/credentials/apps/credentials/views.py
@@ -31,10 +31,15 @@ class SocialMediaMixin:
         context = super().get_context_data(**kwargs)
         request = self.request
         self.site_configuration = request.site.siteconfiguration
+        # pylint: disable-next=unused-variable
         tweet_text = _("I completed a course at {platform_name}. Take a look at my certificate:").format(
             platform_name=self.site_configuration.platform_name
         )
-        twitter_url = "https://twitter.com/intent/tweet?text={{ tweet_text|urlencode }}&url={{ share_url|urlencode }}{% if twitter_username %}&via={{ twitter_username }}{% endif %}"
+        twitter_url = (
+            "https://twitter.com/intent/tweet?text={{ tweet_text|urlencode }}"
+            "&url={{ share_url|urlencode }}{% if twitter_username %}&via="
+            "{{ twitter_username }}{% endif %}"
+        )
         context.update(
             {
                 "twitter_username": self.site_configuration.twitter_username,

--- a/credentials/templates/_actions.html
+++ b/credentials/templates/_actions.html
@@ -1,17 +1,20 @@
 {% load html %}
 {% load i18n %}
 
+
 <div class="message-actions">
   <div class="message-actions-box">
     <h3 class="sr-only">{% trans 'Print or share your certificate' as tmsg %}{{ tmsg | force_escape }}</h3>
-    {# Disabled for now for unclear reasons - LEARNER-6182 is about enabling it #}
-    {% if False and enable_facebook_sharing %}
-      <button title="{% trans 'Share this certificate via Facebook' as tmsg %} {{tmsg | force_escape}}" class="action btn icon-only action-facebook"
+    {% if enable_facebook_sharing %}
+      <button title="{% trans 'Share this certificate via Facebook' as tmsg %} {{tmsg | force_escape}}"
+              id="action-share-facebook"
+              class="action btn icon-only action-facebook"
               data-track-type="click"
               data-track-event="edx.bi.credentials.facebook_share.attempted"
               data-track-event-property-category="certificates"
               data-track-event-property-credential-uuid="{{ user_credential.uuid }}"
               data-track-event-property-program-uuid="{{ user_credential.credential.program_uuid }}">
+        <a class="share-link" target="_blank" href="{{ facebook_url }}" >
         <span class="fa-brands fa-facebook" aria-hidden="true"></span>
         <span class="action-label">{% trans 'Share this certificate via Facebook' as tmsg %}{{ tmsg | force_escape }}</span>
       </button>
@@ -24,7 +27,7 @@
               data-track-event-property-credential-uuid="{{ user_credential.uuid }}"
               data-track-event-property-program-uuid="{{ user_credential.credential.program_uuid }}">
         <a class="share-link" target="_blank"
-           href="https://twitter.com/intent/tweet?text={{ tweet_text|urlencode }}&url={{ share_url|urlencode }}{% if twitter_username %}&via={{ twitter_username }}{% endif %}">
+           href="{{ twitter_url }}">
           <span class="fa-brands fa-twitter" aria-hidden="true"></span>
           <span class="action-label">{% trans 'Tweet this certificate' as tmsg %}{{ tmsg | force_escape }}</span>
         </a>
@@ -32,13 +35,14 @@
     {% endif %}
 
     {% if enable_linkedin_sharing %}
-      <button title="{% trans 'Add to LinkedIn profile' as tmsg %}{{ tmsg|force_escape }}" class="action btn icon-only" data-track-type="click"
-              data-track-event="edx.bi.credentials.linkedin_share.attempted"
-              data-track-event-property-category="certificates"
-              data-track-event-property-credential-uuid="{{ user_credential.uuid }}"
-              data-track-event-property-program-uuid="{{ user_credential.credential.program_uuid }}">
-        <a class="share-link" target="_blank"
-           href="https://www.linkedin.com/profile/add?startTask=CERTIFICATION_NAME">
+      <button title="{% trans 'Add to LinkedIn profile' as tmsg %}{{ tmsg|force_escape }}"
+        class="action btn icon-only"
+        data-track-type="click"
+        data-track-event="edx.bi.credentials.linkedin_share.attempted"
+        data-track-event-property-category="certificates"
+        data-track-event-property-credential-uuid="{{ user_credential.uuid }}"
+        data-track-event-property-program-uuid="{{ user_credential.credential.program_uuid }}">
+        <a class="share-link" target="_blank" href="{{ linkedin_url }}" >
           <span class="fa-brands fa-linkedin" aria-hidden="true"></span>
           <span class="action-label">{% trans 'Add this certificate to your LinkedIn profile' as tmsg %}{{ tmsg | force_escape }}</span>
         </a>


### PR DESCRIPTION
* enable the Facebook sharing button for program certificate
* fixing the LinkedIn sharing button for program certificate, so that (like the course certificate sharing button) it attempts to auto populate the share dialogue on LinkedIn
* moving more of the complexity back into the Python and out of the django template, where it's harder to manage well
* added a tiny bit of type hinting just to make debugging easier

switches to using direct URL instead of SDK  for the Facebook share, so that it won't be blocked by even mildly private browser settings.

FIXES: APER-3333

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
