### PR TITLE
feat: fix broken Twitter link

### DIFF
--- a/credentials/conf/locale/eo/LC_MESSAGES/django.po
+++ b/credentials/conf/locale/eo/LC_MESSAGES/django.po
@@ -331,14 +331,6 @@ msgstr "Ûsé örgänïzätïön nämé Ⱡ'σяєм ιρѕυм ∂σłσя ѕι
 
 #: apps/credentials/views.py
 #, python-brace-format
-msgid ""
-"I completed a course at {platform_name}. Take a look at my certificate:"
-msgstr ""
-"Ì çömplétéd ä çöürsé ät {platform_name}. Täké ä löök ät mý çértïfïçäté: "
-"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
-
-#: apps/credentials/views.py
-#, python-brace-format
 msgid "{first_org} and {second_org}"
 msgstr "{first_org} änd {second_org} Ⱡ'σяєм ιρѕυм ∂σłσя #"
 
@@ -346,6 +338,14 @@ msgstr "{first_org} änd {second_org} Ⱡ'σяєм ιρѕυм ∂σłσя #"
 #, python-brace-format
 msgid "{series_of_orgs}, and {last_org}"
 msgstr "{series_of_orgs}, änd {last_org} Ⱡ'σяєм ιρѕυм ∂σłσя ѕ#"
+
+#: apps/credentials/views.py
+#, python-brace-format
+msgid ""
+"I completed a course at {platform_name}. Take a look at my certificate:"
+msgstr ""
+"Ì çömplétéd ä çöürsé ät {platform_name}. Täké ä löök ät mý çértïfïçäté: "
+"Ⱡ'σяєм ιρѕυм ∂σłσя ѕιт αмєт, ¢σηѕє¢тєтυя α#"
 
 #: apps/credentials_theme_openedx/templates/openedx/credentials/programs/professional-certificate/certificate.html
 msgid ""

--- a/credentials/conf/locale/rtl/LC_MESSAGES/django.po
+++ b/credentials/conf/locale/rtl/LC_MESSAGES/django.po
@@ -289,13 +289,6 @@ msgstr "Ʉsǝ øɹƃɐnᴉzɐʇᴉøn nɐɯǝ"
 
 #: apps/credentials/views.py
 #, python-brace-format
-msgid ""
-"I completed a course at {platform_name}. Take a look at my certificate:"
-msgstr ""
-"Ɨ ɔøɯdlǝʇǝd ɐ ɔønɹsǝ ɐʇ {platform_name}. Ŧɐʞǝ ɐ løøʞ ɐʇ ɯʎ ɔǝɹʇᴉɟᴉɔɐʇǝ:"
-
-#: apps/credentials/views.py
-#, python-brace-format
 msgid "{first_org} and {second_org}"
 msgstr "{first_org} ɐnd {second_org}"
 
@@ -303,6 +296,13 @@ msgstr "{first_org} ɐnd {second_org}"
 #, python-brace-format
 msgid "{series_of_orgs}, and {last_org}"
 msgstr "{series_of_orgs}, ɐnd {last_org}"
+
+#: apps/credentials/views.py
+#, python-brace-format
+msgid ""
+"I completed a course at {platform_name}. Take a look at my certificate:"
+msgstr ""
+"Ɨ ɔøɯdlǝʇǝd ɐ ɔønɹsǝ ɐʇ {platform_name}. Ŧɐʞǝ ɐ løøʞ ɐʇ ɯʎ ɔǝɹʇᴉɟᴉɔɐʇǝ:"
 
 #: apps/credentials_theme_openedx/templates/openedx/credentials/programs/professional-certificate/certificate.html
 msgid ""


### PR DESCRIPTION
a re-factor to fix some of the other social sharing links had broken the Twitter link. This standardizes the link format for social sharing for the program certificates, and removes all of the parsing and conditionals  for those links from the template.

FIXES: APER-3417

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
