### PR TITLE
build: upgrade Python version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,12 +19,12 @@ RUN apt-get update && \
     apt-get install -y software-properties-common && \
     apt-add-repository -y ppa:deadsnakes/ppa && apt-get update && \
     apt-get upgrade -qy && apt-get install language-pack-en locales gettext git \
-    python3.8-dev python3.8-venv libmysqlclient-dev libssl-dev build-essential wget unzip pkg-config -qy && \
+    python3.11-dev python3.11-venv libmysqlclient-dev libssl-dev build-essential wget unzip pkg-config -qy && \
     rm -rf /var/lib/apt/lists/*
 
 # Create Python env
 ENV VIRTUAL_ENV=/edx/app/credentials/venvs/credentials
-RUN python3.8 -m venv $VIRTUAL_ENV
+RUN python3.11 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Create Node env


### PR DESCRIPTION
This PR will upgrade the version of Python used in docker images created from the public repos Dockerfile.

Upgrading the Python version is part of the changes for the Redwood release of Open edX.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
