### PR TITLE
feat!: suspend building Docker image for arm64

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -6,7 +6,7 @@ on:
       - master
     tags:
       - open-release/*
-jobs:  
+jobs:
   push:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
@@ -31,7 +31,7 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -50,8 +50,8 @@ jobs:
           tags: |
             openedx/credentials:${{ steps.get-tag-name.outputs.result }}
             openedx/credentials:${{ github.sha }}
-          platforms: linux/amd64,linux/arm64
-      
+          platforms: linux/amd64
+
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v5
         with:
@@ -61,4 +61,4 @@ jobs:
           tags: |
             openedx/credentials-dev:${{ steps.get-tag-name.outputs.result }}
             openedx/credentials-dev:${{ github.sha }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64


### PR DESCRIPTION
There seems to be an issue installing a required dependency (`didkit`) for the `arm64` platform. Since one of the two platforms are failing, it causes the good image for the `linux/amd64` platform to not upload either.

This is keeping us from being able to push an updated Docker image running Python 3.11 to DockerHub and impeding Devstack developers.

We are under the impression that only 2U uses this Dockerfile and this shouldn't affect the larger community.

For additional details, please see the public Credentials issue: https://github.com/openedx/credentials/issues/2477.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
