### PR TITLE
feat:  prerequisite for RUM

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -275,7 +275,7 @@ edx-django-sites-extensions==4.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -199,7 +199,7 @@ django-rest-swagger==2.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-django-ses==4.0.0
+django-ses==4.1.0
     # via -r requirements/production.txt
 django-simple-history==3.5.0
     # via
@@ -275,7 +275,7 @@ edx-django-sites-extensions==4.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-django-utils==5.14.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -138,7 +138,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.13.0
+edx-django-utils==5.14.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -138,7 +138,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.14.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -206,7 +206,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.14.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -206,7 +206,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -124,7 +124,7 @@ django-ratelimit==4.1.0
     # via -r requirements/base.txt
 django-rest-swagger==2.2.0
     # via -r requirements/base.txt
-django-ses==4.0.0
+django-ses==4.1.0
     # via -r requirements/production.in
 django-simple-history==3.5.0
     # via -r requirements/base.txt
@@ -173,7 +173,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.14.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -173,7 +173,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -190,7 +190,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.14.0
+edx-django-utils==5.14.1
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -190,7 +190,7 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.13.0
+edx-django-utils==5.14.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions


### PR DESCRIPTION
This updates edx-django-utils to the newest version, which will enable us to enable RUM in program certs once @iamsobanjaved's work in https://github.com/edx/edx-internal/pull/10902 is complete.

(note we don't actually have to wait for that other PR to deploy credentials)

FIXES: APER-3470

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
