### PR TITLE
feat:   use the frontendmonitoringmiddleware if configured

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -88,6 +88,7 @@ MIDDLEWARE = (
     "edx_django_utils.monitoring.CookieMonitoringMiddleware",
     "edx_django_utils.monitoring.CachedCustomMonitoringMiddleware",
     "edx_django_utils.monitoring.MonitoringMemoryMiddleware",
+    "edx_django_utils.monitoring.FrontendMonitoringMiddleware",
     "edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.locale.LocaleMiddleware",


### PR DESCRIPTION
* enables the front end monitoring middleware

FIXES: APER-3470

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
