### PR TITLE
fix: replace deprecated github actions

### DIFF
--- a/.github/workflows/migrations-mysql8-check.yml
+++ b/.github/workflows/migrations-mysql8-check.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
       id: cache-dependencies
       uses: actions/cache@v4


### PR DESCRIPTION
**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
