### PR TITLE
feat: management command to synchronize is_active

### DIFF
--- a/credentials/apps/core/management/commands/make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/make_is_active_match_platform.py
@@ -1,6 +1,6 @@
 """
-Django managment command to make the is_active status on a credentials user
-be True if it the user's LMS is_active status is True.
+Django management command to make the is_active status on a credentials user
+be True if the user's LMS is_active status is True.
 
 If the credentials user is_active=True we don't need to synchronize because that
 inconsistency is fine. But there can be user problems if they can log in to the

--- a/credentials/apps/core/management/commands/make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/make_is_active_match_platform.py
@@ -2,9 +2,9 @@
 Django management command to make the is_active status on a credentials user
 be True if the user's LMS is_active status is True.
 
-If the credentials user is_active=True we don't need to synchronize because that
+If the credentials user is_active=True but the LMS user is_active=False, we don't need to synchronize because that
 inconsistency is fine. But there can be user problems if they can log in to the
-LMS but the credentials user has been set inactive, so we fix inconsistencies in
+LMS but the credentials user has been set inactive, so we have to fix inconsistencies in
 that one direction.
 """
 

--- a/credentials/apps/core/management/commands/make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/make_is_active_match_platform.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         logger.info(f"using {site_configs.site.domain} for user queries")
 
         # loop over users in batches
-        logger.warning(f"Start processing {count_users} IDs with is_active=True")
+        logger.warning(f"Start processing {count_users} inactive Credentials user accounts")
         for x in range(0, count_users, offset):
             slice_size = min(count_users, x + offset)
             curr_users = inactive_credentials_users[x:slice_size]
@@ -71,7 +71,7 @@ class Command(BaseCommand):
                 if user.username in is_active_statuses and user.is_active != is_active_statuses[user.username]:
                     self.enable_user(user, verbosity, dry_run)
                 else:
-                    logger.error(f"Could not get is_active for user {user.username}")
+                    logger.error(f"Could not get is_active for user with lms_user_id {user.lms_user_id}")
             if x + slice_size < count_users:
                 time.sleep(pause)
 
@@ -82,7 +82,7 @@ class Command(BaseCommand):
         users: List["AbstractUser"],
         site_config: SiteConfiguration,
     ) -> Dict[str, bool]:
-        """Get is_active status for a list of users.
+        """Get is_active status from the LMS for a list of users.
 
         Args:
             users: List of user objects

--- a/credentials/apps/core/management/commands/make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/make_is_active_match_platform.py
@@ -1,0 +1,123 @@
+"""
+Django managment command to make the is_active status on a credentials user
+be True if it the user's LMS is_active status is True.
+
+If the credentials user is_active=True we don't need to synchronize because that
+inconsistency is fine. But there can be user problems if they can log in to the
+LMS but the credentials user has been set inactive, so we fix inconsistencies in
+that one direction.
+"""
+
+import logging
+import time
+from typing import TYPE_CHECKING, Dict, List
+from urllib.parse import urljoin
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand
+
+from credentials.apps.core.models import SiteConfiguration
+
+
+if TYPE_CHECKING:
+    from django.contrib.auth.models import AbstractUser
+
+logger = logging.getLogger(__name__)
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch_size", type=int, default=10, help="Number of IDs to process at a time. Default %(default)"
+        )
+        parser.add_argument(
+            "--pause_secs", type=int, default=1, help="Number of seconds to pause between calls. Default %(default)"
+        )
+        parser.add_argument("--verbose", action="store_true", help="Log each update")
+        parser.add_argument(
+            "--site_id", type=int, default=0, help="ORM id of the site to query for lms_user_ids. Default %(default)"
+        )
+        parser.add_argument("--dry_run", action="store_true", help="Don't actually change the data")
+
+    def handle(self, *args, **options):
+        """
+        Get batches of user info from accounts and update the lms_user_id
+        for users who are missing it.
+        """
+        logger.info("Beginning is_active matching.")
+        inactive_credentials_users = User.objects.filter(is_active=False)
+        count_users = inactive_credentials_users.count()
+        offset = options.get("batch_size")
+        pause = options.get("pause_secs")
+        verbosity = options.get("verbose")
+        site_id = options.get("site_id")
+        dry_run = options.get("dry_run")
+
+        site_configs = SiteConfiguration.objects.first()
+        if site_id:
+            # multiple are sites managing different users
+            logger.info(f"using site id {site_id} for user queries")
+            site_configs = SiteConfiguration.objects.get(site__id=site_id)
+        logger.info(f"using {site_configs.site.domain} for user queries")
+
+        # loop over users in batches
+        logger.warning(f"Start processing {count_users} IDs with is_active=True")
+        for x in range(0, count_users, offset):
+            slice_size = min(count_users, x + offset)
+            curr_users = inactive_credentials_users[x:slice_size]
+            is_active_statuses = self.get_is_active(curr_users, site_configs)
+            for user in curr_users:
+                if user.username in is_active_statuses and user.is_active != is_active_statuses[user.username]:
+                    self.enable_user(user, verbosity, dry_run)
+                else:
+                    logger.error(f"Could not get is_active for user {user.username}")
+            if x + slice_size < count_users:
+                time.sleep(pause)
+
+        logger.info("Finished is_active matching.")
+
+    def get_is_active(
+        self,
+        users: List["AbstractUser"],
+        site_config: SiteConfiguration,
+    ) -> Dict[str, bool]:
+        """Get is_active status for a list of users.
+
+        Args:
+            users: List of user objects
+            site_config: SiteConfiguration object of Site to query
+
+        Returns:
+            a dict of form { username[str]: is_active[bool] }
+        """
+        query_param_names = ",".join(user.username for user in users)
+        user_url = urljoin(site_config.user_api_url, f"accounts?username={query_param_names}")
+        user_response = site_config.api_client.get(user_url)
+
+        user_dict = {}
+        if user_response.status_code == 200:
+            user_data = user_response.json()
+            for user_profile in user_data:
+                user_dict[user_profile["username"]] = user_profile["id"]
+        else:
+            logger.error(
+                f"{urljoin(site_config.user_api_url, 'accounts?username=')}[usernames redacted]"
+                f"returned status {user_response.status_code}"
+            )
+
+        return user_dict
+
+    def enable_user(self, user: "AbstractUser", verbosity: bool, dry_run: bool) -> None:
+        """Update the is_active status for the user.
+
+        Although this management command is written to only update from False to True,
+
+        """
+        user.is_active = True
+        dry_run_msg = "(dry run) " if dry_run else ""
+        if verbosity:
+            logger.info(f"{dry_run_msg}Setting user with lms_user_id {user.lms_user_id} to active status")
+        # use update_fields to just update this one piece of data
+        if not dry_run:
+            user.save(update_fields=["is_active"])

--- a/credentials/apps/core/management/commands/tests/test_make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/tests/test_make_is_active_match_platform.py
@@ -1,0 +1,106 @@
+"""
+Tests for the make_is_active_match_platform management command
+"""
+
+import json
+
+import responses
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.test import TestCase
+
+from credentials.apps.core.tests.factories import UserFactory
+from credentials.apps.core.tests.mixins import SiteMixin
+
+
+User = get_user_model()
+
+JSON = "application/json"
+
+
+class IsActiveMatchSyncTests(SiteMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user_active = UserFactory(username="is_active", is_active=True, id=2)
+        self.user_inactive = UserFactory(username="is_inactive", is_active=False, id=3)
+
+    def mock_account_api_response(
+        self,
+        user1_is_active_on_lms: bool,
+        user2_is_active_on_lms: bool,
+        status: int = 200,
+    ):
+        url = self.site.siteconfiguration.user_api_url + "accounts"
+        user1_active_response = {"username": "is_active", "is_active": user1_is_active_on_lms, "id": 2}
+        user2_active_response = {"username": "is_inactive", "is_active": user2_is_active_on_lms, "id": 3}
+        body = [user1_active_response, user2_active_response]
+        responses.add(
+            responses.GET,
+            url,
+            body=json.dumps(body),
+            content_type=JSON,
+            status=status,
+            match_querystring=False,
+        )
+
+    @responses.activate
+    def test_unchanged_if_is_active_matches(self):
+        """Test nothing changes if is_active matches on LMS and Credentials."""
+        self.mock_access_token_response()
+        self.mock_account_api_response(True, False)
+
+        user_active = User.objects.get(username="is_active")
+        user_inactive = User.objects.get(username="is_inactive")
+
+        call_command("make_is_active_match_platform", verbose=True)
+
+        self.assertTrue(user_active.is_active)
+        self.assertFalse(user_inactive.is_active)
+
+    @responses.activate
+    def test_changes_only_false_to_true(self):
+        """Test that a mismatch changes False to True, but not vice versa, on mismatch between credentials and LMS."""
+        self.mock_access_token_response()
+        self.mock_account_api_response(False, True)
+        call_command("make_is_active_match_platform", verbose=True)
+
+        user_active = User.objects.get(username="is_active")
+        user_inactive = User.objects.get(username="is_inactive")
+        self.assertTrue(user_active.is_active)
+        self.assertTrue(user_inactive.is_active)
+
+    @responses.activate
+    def test_update_does_nothing_on_404(self):
+        """Test that nothing changes if the response is a 404"""
+        self.mock_access_token_response()
+        self.mock_account_api_response(False, True, status=404)
+        call_command("make_is_active_match_platform", verbose=True)
+
+        user_active = User.objects.get(username="is_active")
+        user_inactive = User.objects.get(username="is_inactive")
+        self.assertTrue(user_active.is_active)
+        self.assertFalse(user_inactive.is_active)
+
+    @responses.activate
+    def test_update_site(self):
+        """Test that the command works as expected with the site ID given."""
+        self.mock_access_token_response()
+        self.mock_account_api_response(False, True)
+        call_command("make_is_active_match_platform", verbose=True, site_id=self.site_configuration.site_id)
+
+        user_active = User.objects.get(username="is_active")
+        user_inactive = User.objects.get(username="is_inactive")
+        self.assertTrue(user_active.is_active)
+        self.assertTrue(user_inactive.is_active)
+
+    @responses.activate
+    def test_dry_run(self):
+        """verify nothing changes on a dry run"""
+        self.mock_access_token_response()
+        self.mock_account_api_response(False, True, status=404)
+        call_command("make_is_active_match_platform", dry_run=True, verbose=True, pause_secs=0)
+
+        user_active = User.objects.get(username="is_active")
+        user_inactive = User.objects.get(username="is_inactive")
+        self.assertTrue(user_active.is_active)
+        self.assertFalse(user_inactive.is_active)


### PR DESCRIPTION
this creates a management command to synchronize is_active between LMS and credentials. It only goes in one direction (the learner on credentials to is_active = True if that is the case on LMS), because the alternative is not a problem and is much more costly to update.

FIXES: APER-3346
