### PR TITLE
docs: update README and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TOX = ''
 	extract_translations dummy_translations compile_translations fake_translations pull_translations \
 	detect_changed_source_translations validate_translations check_translations_up_to_date \
 	check_keywords pii_check coverage \
-	quality_and_translations_tests_suite unit_tests_suite docs
+	docs
 
 ifdef TOXENV
 TOX := tox -- #to isolate each tox environment if TOXENV is defined

--- a/README.rst
+++ b/README.rst
@@ -1,28 +1,37 @@
-edX Credentials Service   |Codecov|_
+edX Credentials Service |Codecov|_
 ====================================
+
 .. |Codecov| image:: http://codecov.io/github/edx/credentials/coverage.svg?branch=master
 .. _Codecov: http://codecov.io/github/edx/credentials?branch=master
 
-This repository contains the edX Credentials Service, which supports course and program certificates. This service is a replacement for the ``certificates`` app in ``edx-platform``.
-Credentials can be run as part of devstack_.
+This repository contains the edX Credentials Service, which supports course and program certificates. This service is a
+replacement for the ``certificates`` app in ``edx-platform``.
+
+Credentials can be run as part of devstack_ or Tutor_ (using the tutor_credentials_ plugin).
 
 .. _devstack: https://github.com/openedx/devstack
-
+.. _tutor: https://docs.tutor.edly.io/
+.. _tutor_credentials: https://github.com/overhangio/tutor-credentials
 
 Where to run `make` commands
 --------------------------
-Due to the nature of developing in containers, some commands must be ran inside the container, and some locally.
-Currently most commands can be ran either inside the container or inside a local virtual environement, once developer
-requirements have been installed (`make requirements`)
 
-The exception to this, is commands that run inside their own containers, which currently is only the testing suites ::
-
-  make quality_and_translations_tests_suite
-  make unit_tests_suite
+Due to the nature of developing in containers, some commands must be ran inside the container. Currently most commands
+can be ran either inside the container or inside a local virtual environement, once developer requirements have been
+installed (using `make requirements` target).
 
 Frontend Development
 --------------------
-When developing frontend code in Credentials, some of the code must be transpiled and bundled for it to be usable. This includes the React components found in ``credentials/static/components`` and the SASS code found at ``credentials/static/sass``. In order to view your changes, you must run one of the `make static` commands. `make static` builds and collects your static assets once, while `make static.watch` will continue to watch for changes in your code and rebuild/recollect whenever you save. When using `make static.watch` it only triggers after save, so if you have existing changes, you make need to run `make static` once first, or make a small change to an existing file and save it so it triggers a rebuild.
+
+The `Learner Record`_ feature and frontend components have been extracted into a dedicated MFE.
+
+When developing frontend code in Credentials, some of the code must be transpiled and bundled for it to be usable. The
+SASS code found in the ``credentials/static/sass`` directory of this project.
+
+In order to view your changes, you must run one of the `make static` commands. `make static` builds and collects your
+static assets once, while `make static.watch` will continue to watch for changes in your code and rebuild/recollect
+whenever you save. When using `make static.watch` it only triggers after save, so if you have existing changes, you
+need to run `make static` once first, or make a small change to an existing file and save it so it triggers a rebuild.
 
 To see changes locally, from your devstack repo run ::
 
@@ -30,14 +39,16 @@ To see changes locally, from your devstack repo run ::
   make static
   make static.watch
 
+.. _Learner Record: https://github.com/openedx/frontend-app-learner-record
+
 Testing
 -------
 
 In order for developers to have a consistent experience between CI and local testing, we are using a locally built
 container image that mimics the ones that Github Actions uses.
 
-NOTE: The first time you run any of the test suites below, it
-will build the image which will take a few minutes. Following test runs will be quicker.
+NOTE: The first time you run any of the test suites below, it will build the image which will take a few minutes.
+Following test runs will be quicker.
 
 To run python and javascript tests locally ("unit_tests" in CI) ::
 
@@ -56,7 +67,8 @@ isort and formatting (`black`) quality issues can be fixed automatically by runn
 Documentation
 -------------
 
-`Documentation`_ is hosted on Read the Docs. The source is hosted in this repo's `docs`_ directory. To contribute, please open a PR against this repo.
+`Documentation`_ is hosted on Read the Docs. The source is hosted in this repo's `docs`_ directory. To contribute,
+please open a PR against this repo.
 
 .. _Documentation: https://edx-credentials.readthedocs.io/en/latest/
 .. _docs: https://github.com/openedx/credentials/tree/master/docs
@@ -64,7 +76,8 @@ Documentation
 License
 -------
 
-The code in this repository is licensed under version 3 of the AGPL unless otherwise noted. Please see the LICENSE_ file for details.
+The code in this repository is licensed under version 3 of the AGPL unless otherwise noted. Please see the LICENSE_ file
+for details.
 
 .. _LICENSE: https://github.com/openedx/credentials/blob/master/LICENSE
 

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Where to run `make` commands
 
 Due to the nature of developing in containers, some commands must be ran inside the container. Currently most commands
 can be ran either inside the container or inside a local virtual environement, once developer requirements have been
-installed (using `make requirements` target).
+installed (using the `make requirements` target).
 
 Frontend Development
 --------------------


### PR DESCRIPTION
A PR to cleanup the Credentials README. Additionally, this removes some Makefile targets that are no longer valid, their functionality had been removed in an earlier PR.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
