### PR TITLE
feat: Re-enable Docker image builds for arm64

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -50,7 +50,7 @@ jobs:
           tags: |
             openedx/credentials:${{ steps.get-tag-name.outputs.result }}
             openedx/credentials:${{ github.sha }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
 
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v5

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -61,4 +61,4 @@ jobs:
           tags: |
             openedx/credentials-dev:${{ steps.get-tag-name.outputs.result }}
             openedx/credentials-dev:${{ github.sha }}
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -33,11 +33,11 @@ bleach==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.34.159
+boto3==1.34.161
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.34.159
+botocore==1.34.161
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -123,7 +123,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/production.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -379,7 +379,7 @@ google-api-core[grpc]==2.19.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.140.0
+google-api-python-client==2.141.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -405,7 +405,7 @@ google-cloud-core==2.4.1
     #   -r requirements/production.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.17.1
+google-cloud-firestore==2.17.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -442,7 +442,7 @@ grpcio==1.65.4
     #   -r requirements/production.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.62.3
+grpcio-status==1.65.4
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -606,7 +606,7 @@ proto-plus==1.24.0
     #   -r requirements/production.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==4.25.4
+protobuf==5.27.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -799,7 +799,7 @@ semantic-version==2.10.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -853,11 +853,11 @@ text-unidecode==1.3
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/dev.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/dev.txt
 types-pyyaml==6.0.12.20240808
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/base.in
 django==4.2.15
     # via
@@ -188,7 +188,7 @@ google-api-core[grpc]==2.19.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.140.0
+google-api-python-client==2.141.0
     # via firebase-admin
 google-auth==2.33.0
     # via
@@ -204,7 +204,7 @@ google-cloud-core==2.4.1
     # via
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.17.1
+google-cloud-firestore==2.17.2
     # via firebase-admin
 google-cloud-storage==2.18.2
     # via firebase-admin
@@ -222,7 +222,7 @@ grpcio==1.65.4
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.62.3
+grpcio-status==1.65.4
     # via google-api-core
 httplib2==0.22.0
     # via
@@ -282,7 +282,7 @@ proto-plus==1.24.0
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==4.25.4
+protobuf==5.27.3
     # via
     #   google-api-core
     #   google-cloud-firestore
@@ -368,7 +368,7 @@ segment-analytics-python==2.3.2
     # via -r requirements/base.in
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   django-rest-swagger
     #   sailthru-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -98,7 +98,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/test.txt
 dill==0.3.8
     # via
@@ -286,7 +286,7 @@ google-api-core[grpc]==2.19.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.140.0
+google-api-python-client==2.141.0
     # via
     #   -r requirements/test.txt
     #   firebase-admin
@@ -308,7 +308,7 @@ google-cloud-core==2.4.1
     #   -r requirements/test.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.17.1
+google-cloud-firestore==2.17.2
     # via
     #   -r requirements/test.txt
     #   firebase-admin
@@ -335,7 +335,7 @@ grpcio==1.65.4
     #   -r requirements/test.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.62.3
+grpcio-status==1.65.4
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -463,7 +463,7 @@ proto-plus==1.24.0
     #   -r requirements/test.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==4.25.4
+protobuf==5.27.3
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -619,7 +619,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -665,11 +665,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.txt
 types-pyyaml==6.0.12.20240808
     # via django-stubs

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -48,7 +48,7 @@ requests==2.32.3
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==8.0.2
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.44.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via -r requirements/pip.in
-setuptools==72.1.0
+setuptools==72.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,9 +20,9 @@ backoff==2.2.1
     #   segment-analytics-python
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.34.159
+boto3==1.34.161
     # via django-ses
-botocore==1.34.159
+botocore==1.34.161
     # via
     #   boto3
     #   s3transfer
@@ -75,7 +75,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/base.txt
 django==4.2.15
     # via
@@ -237,7 +237,7 @@ google-api-core[grpc]==2.19.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.140.0
+google-api-python-client==2.141.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
@@ -259,7 +259,7 @@ google-cloud-core==2.4.1
     #   -r requirements/base.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.17.1
+google-cloud-firestore==2.17.2
     # via
     #   -r requirements/base.txt
     #   firebase-admin
@@ -288,7 +288,7 @@ grpcio==1.65.4
     #   -r requirements/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.62.3
+grpcio-status==1.65.4
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -385,7 +385,7 @@ proto-plus==1.24.0
     #   -r requirements/base.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==4.25.4
+protobuf==5.27.3
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -509,7 +509,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -91,7 +91,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/base.txt
 dill==0.3.8
     # via pylint
@@ -261,7 +261,7 @@ google-api-core[grpc]==2.19.1
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.140.0
+google-api-python-client==2.141.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
@@ -283,7 +283,7 @@ google-cloud-core==2.4.1
     #   -r requirements/base.txt
     #   google-cloud-firestore
     #   google-cloud-storage
-google-cloud-firestore==2.17.1
+google-cloud-firestore==2.17.2
     # via
     #   -r requirements/base.txt
     #   firebase-admin
@@ -310,7 +310,7 @@ grpcio==1.65.4
     #   -r requirements/base.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.62.3
+grpcio-status==1.65.4
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -425,7 +425,7 @@ proto-plus==1.24.0
     #   -r requirements/base.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==4.25.4
+protobuf==5.27.3
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -571,7 +571,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -616,9 +616,9 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomlkit==0.13.0
+tomlkit==0.13.2
     # via pylint
-tox==4.17.1
+tox==4.18.0
     # via -r requirements/test.in
 typing-extensions==4.12.2
     # via


### PR DESCRIPTION
The maintainers of `didkit` have released an update that fixes an issue where it would not build on arm64-based systems.

This resolves an issue with Devstack and developers running devstack on Apple silicon-based machines.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
