### PR TITLE
feat: fixing a bug that always assumed active status was true on LMS

### DIFF
--- a/credentials/apps/core/management/commands/make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/make_is_active_match_platform.py
@@ -68,10 +68,10 @@ class Command(BaseCommand):
             curr_users = inactive_credentials_users[x:slice_size]
             is_active_statuses = self.get_is_active(curr_users, site_configs)
             for user in curr_users:
-                if user.username in is_active_statuses and user.is_active != is_active_statuses[user.username]:
-                    self.enable_user(user, verbosity, dry_run)
-                else:
+                if user.username not in is_active_statuses:
                     logger.error(f"Could not get is_active for user with lms_user_id {user.lms_user_id}")
+                elif user.is_active != is_active_statuses[user.username]:
+                    self.enable_user(user, verbosity, dry_run)
             if x + slice_size < count_users:
                 time.sleep(pause)
 
@@ -99,7 +99,7 @@ class Command(BaseCommand):
         if user_response.status_code == 200:
             user_data = user_response.json()
             for user_profile in user_data:
-                user_dict[user_profile["username"]] = user_profile["id"]
+                user_dict[user_profile["username"]] = user_profile["is_active"]
         else:
             logger.error(
                 f"{urljoin(site_config.user_api_url, 'accounts?username=')}[usernames redacted]"

--- a/credentials/apps/core/management/commands/tests/test_make_is_active_match_platform.py
+++ b/credentials/apps/core/management/commands/tests/test_make_is_active_match_platform.py
@@ -82,6 +82,21 @@ class IsActiveMatchSyncTests(SiteMixin, TestCase):
         self.assertFalse(user_inactive.is_active)
 
     @responses.activate
+    def test_update_does_nothing_if_learner_missing_on_lms(self):
+        """Test that nothing changes if the learner isn't found on the LMS"""
+        self.mock_access_token_response()
+        self.mock_account_api_response(False, True, status=404)
+
+        UserFactory(username="lms_absent_is_active", is_active=True, id=30)
+        UserFactory(username="lms_absent_is_inactive", is_active=False, id=40)
+        call_command("make_is_active_match_platform", verbose=True)
+
+        user_active = User.objects.get(username="lms_absent_is_active")
+        user_inactive = User.objects.get(username="lms_absent_is_inactive")
+        self.assertTrue(user_active.is_active)
+        self.assertFalse(user_inactive.is_active)
+
+    @responses.activate
     def test_update_site(self):
         """Test that the command works as expected with the site ID given."""
         self.mock_access_token_response()


### PR DESCRIPTION
the limitations of unit tests over integration tests! I was calling the wrong parameter in my tests, but my mocked API calls were returning what I thought I should be calling.

While I was in there I improved some error logic for learner inconsistency and added a new test for the improved error logic.
