### PR TITLE
feat: DEPR USE-JWT-COOKIE header

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -110,7 +110,7 @@ MIDDLEWARE = (
 
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers + ("use-jwt-cookie",)
+CORS_ALLOW_HEADERS = corsheaders_default_headers
 CORS_ORIGIN_WHITELIST = []
 
 ROOT_URLCONF = "credentials.urls"


### PR DESCRIPTION
This repo is no longer using USE-JWT-COOKIE header, since it has the required edx-drf-extensions>10.2.0, where it was fully removed.

This is final clean-up for this repo.

See "[DEPR]: USE-JWT-COOKIE header" for more details:
- https://github.com/openedx/edx-drf-extensions/issues/371

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
