### PR TITLE
Revert "feat: DEPR USE-JWT-COOKIE header"

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -110,7 +110,7 @@ MIDDLEWARE = (
 
 # Enable CORS
 CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOW_HEADERS = corsheaders_default_headers
+CORS_ALLOW_HEADERS = corsheaders_default_headers + ("use-jwt-cookie",)
 CORS_ORIGIN_WHITELIST = []
 
 ROOT_URLCONF = "credentials.urls"


### PR DESCRIPTION
Reverts openedx/credentials#2554

A similar PR may have broken edx-platform, so reverting until investigation has completed. See https://github.com/openedx/edx-platform/pull/35397