### PR TITLE
chore: upgrade workflows and Dockerfile to use ubuntu 24 LTS

### DIFF
--- a/.github/workflows/migrations-mysql8-check.yml
+++ b/.github/workflows/migrations-mysql8-check.yml
@@ -10,11 +10,10 @@ on:
 jobs:
   check_migrations:
     name: check migrations
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ 3.11 ]
 
     steps:
     - name: Checkout repo

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal as base
+FROM ubuntu:noble AS base
 
 # System requirements
 # - git; Used to pull in particular requirements from github rather than pypi,
@@ -30,9 +30,9 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Create Node env
 RUN pip install nodeenv
 ENV NODE_ENV=/edx/app/credentials/nodeenvs/credentials
-RUN nodeenv $NODE_ENV --node=18.17.1 --prebuilt
+RUN nodeenv $NODE_ENV --node=20.17.0 --prebuilt
 ENV PATH="$NODE_ENV/bin:$PATH"
-RUN npm install -g npm@9.x.x
+RUN npm install -g npm@10.x.x
 
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
@@ -94,7 +94,7 @@ CMD gunicorn --workers=2 --name credentials -c /edx/app/credentials/credentials/
 
 # We don't switch back to the app user for devstack because we need devstack users to be
 # able to update requirements and generally run things as root.
-FROM base as dev
+FROM base AS dev
 USER root
 ENV DJANGO_SETTINGS_MODULE credentials.settings.devstack
 RUN pip install -r /edx/app/credentials/credentials/requirements/dev.txt


### PR DESCRIPTION
**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
