### PR TITLE
remove traces of EdxRestApiClient

### DIFF
--- a/credentials/apps/catalog/utils.py
+++ b/credentials/apps/catalog/utils.py
@@ -35,7 +35,7 @@ class CatalogDataSynchronizer:
 
         Arguments:
             site (Site): The site that all fetch models should connect to
-            api_client (EdxRestApiClient): The client through which all API calls will be made
+            api_client (ApiClient): The client through which all API calls will be made
             catalog_api_url (str): The full URL root of the catalog API to hit (ex. "https://example.com/api/v1/")
             page_size (int): An optional field to denote the number of results per page to retrieve from the API
 


### PR DESCRIPTION
chore: updating a docstring to match reality

this no longer uses an `EdxRestApiClient`. This is the last trace of the client; the defunct tests using it were deleted September 2023 (https://github.com/openedx/credentials/pull/2213)
