### PR TITLE
fix: update version of ubuntu used in CI workflows

### DIFF
--- a/.github/workflows/migrations-mysql8-check.yml
+++ b/.github/workflows/migrations-mysql8-check.yml
@@ -10,11 +10,10 @@ on:
 jobs:
   check_migrations:
     name: check migrations
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ ubuntu-20.04 ]
-        python-version: [ 3.8 ]
+        python-version: [ 3.11 ]
 
     steps:
     - name: Checkout repo


### PR DESCRIPTION
This PR reintroduces the upgraded version of Ubuntu in CI workflows from PR #2556. Dockerfile updates will be reintroduced separate from this change.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
