### PR TITLE
fix: read the docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,15 @@
 # .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required: the version of this file's schema.
 version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-latest
+  tools:
+    python: "3.11"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -11,6 +17,6 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.8"
+   version: "3.11"
    install:
    - requirements: requirements/docs.txt


### PR DESCRIPTION
Updates `.readthedocs.yml` to fix a broken build #2577

[Conifugration docs](https://docs.readthedocs.io/en/stable/config-file/v2.html)

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
