### PR TITLE
fix: update RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -17,6 +17,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: "3.11"
-   install:
-   - requirements: requirements/docs.txt
+  install:
+  - requirements: requirements/docs.txt
+  - method: pip
+    path: .


### PR DESCRIPTION
Removed invalid `python.version` key

Failed build: https://app.readthedocs.org/projects/edx-credentials/builds/25658344/

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
