### PR TITLE
fix: update rtd config path

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,4 +20,4 @@ python:
   install:
   - requirements: requirements/docs.txt
   - method: pip
-    path: .
+    path: credentials


### PR DESCRIPTION
Reference: https://docs.readthedocs.io/en/stable/config-file/v2.html#packages

Failed build: https://app.readthedocs.org/projects/edx-credentials/builds/25671070/

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
