### PR TITLE
docs: test configuration without pip install for directory

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,5 +19,3 @@ sphinx:
 python:
   install:
   - requirements: requirements/docs.txt
-  - method: pip
-    path: credentials


### PR DESCRIPTION
Builds are still failing, work on the issue - https://github.com/openedx/credentials/issues/2577