### PR TITLE
fix: fix typo in noindex meta tag

### DIFF
--- a/credentials/templates/base.html
+++ b/credentials/templates/base.html
@@ -12,7 +12,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="robots" context="noindex">
+    <meta name="robots" content="noindex">
     <title>{% block title %}{% endblock title %}</title>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />


### PR DESCRIPTION
Fixes a typo in the `noindex` meta tag in the base program cert template. 

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
