### PR TITLE
feat: Re-enable image builds for arm64 for redwood

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -51,7 +51,6 @@ jobs:
             openedx/credentials:${{ steps.get-tag-name.outputs.result }}
             openedx/credentials:${{ github.sha }}
           platforms: linux/amd64,linux/arm64
-      
       - name: Build and push dev Docker image
         uses: docker/build-push-action@v5
         with:

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -44,11 +44,11 @@ bleach==6.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.34.99
+boto3==1.34.161
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.34.99
+botocore==1.34.161
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -127,7 +127,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/production.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -339,11 +339,84 @@ fontawesomefree==6.5.1
     #   -r requirements/production.txt
 gevent==24.2.1
     # via -r requirements/production.txt
+google-api-core[grpc]==2.19.1
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.141.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   firebase-admin
+google-auth==2.33.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-python-client
+google-cloud-core==2.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.17.2
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   firebase-admin
+google-cloud-storage==2.18.2
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   firebase-admin
+google-crc32c==1.5.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.63.2
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-core
+    #   grpcio-status
 greenlet==3.0.3
     # via
     #   -r requirements/production.txt
     #   gevent
-gunicorn==22.0.0
+grpcio==1.65.4
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.65.4
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-core
+gunicorn==23.0.0
     # via -r requirements/production.txt
 httpretty==1.1.4
     # via -r requirements/dev.txt
@@ -487,7 +560,22 @@ polib==1.2.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-i18n-tools
-psutil==5.9.8
+proto-plus==1.24.0
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==5.27.3
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
+psutil==6.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -645,7 +733,7 @@ semantic-version==2.10.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -698,19 +786,11 @@ text-unidecode==1.3
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   python-slugify
-tomli==2.0.1
-    # via
-    #   -r requirements/dev.txt
-    #   black
-    #   pylint
-    #   pyproject-api
-    #   pytest
-    #   tox
-tomlkit==0.12.4
+tomlkit==0.13.2
     # via
     #   -r requirements/dev.txt
     #   pylint
-tox==4.15.0
+tox==4.18.0
     # via -r requirements/dev.txt
 typing-extensions==4.11.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,7 +51,7 @@ defusedxml==0.8.0rc2
     # via
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/base.in
 django==4.2.16
     # via
@@ -165,6 +165,53 @@ fastavro==1.9.4
     # via openedx-events
 fontawesomefree==6.5.1
     # via -r requirements/base.in
+google-api-core[grpc]==2.19.1
+    # via
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.141.0
+    # via firebase-admin
+google-auth==2.33.0
+    # via
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via google-api-python-client
+google-cloud-core==2.4.1
+    # via
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.17.2
+    # via firebase-admin
+google-cloud-storage==2.18.2
+    # via firebase-admin
+google-crc32c==1.5.0
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via google-cloud-storage
+googleapis-common-protos==1.63.2
+    # via
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.65.4
+    # via
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.65.4
+    # via google-api-core
+httplib2==0.22.0
+    # via
+    #   google-api-python-client
+    #   google-auth-httplib2
 idna==3.7
     # via requests
 importlib-metadata==6.11.0
@@ -214,7 +261,18 @@ pillow==10.3.0
     # via -r requirements/base.in
 polib==1.2.0
     # via edx-i18n-tools
-psutil==5.9.8
+proto-plus==1.24.0
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==5.27.3
+    # via
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
+psutil==6.0.0
     # via edx-django-utils
 pycparser==2.22
     # via cffi
@@ -277,7 +335,7 @@ segment-analytics-python==2.3.2
     # via -r requirements/base.in
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   django-rest-swagger
     #   sailthru-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -101,7 +101,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/test.txt
 dill==0.3.8
     # via
@@ -255,6 +255,72 @@ filelock==3.14.0
     #   virtualenv
 fontawesomefree==6.5.1
     # via -r requirements/test.txt
+google-api-core[grpc]==2.19.1
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.141.0
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+google-auth==2.33.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-python-client
+google-cloud-core==2.4.1
+    # via
+    #   -r requirements/test.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.17.2
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+google-cloud-storage==2.18.2
+    # via
+    #   -r requirements/test.txt
+    #   firebase-admin
+google-crc32c==1.5.0
+    # via
+    #   -r requirements/test.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/test.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.63.2
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.65.4
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.65.4
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+httplib2==0.22.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-python-client
+    #   google-auth-httplib2
 httpretty==1.1.4
     # via -r requirements/test.txt
 idna==3.7
@@ -366,7 +432,20 @@ polib==1.2.0
     # via
     #   -r requirements/test.txt
     #   edx-i18n-tools
-psutil==5.9.8
+proto-plus==1.24.0
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==5.27.3
+    # via
+    #   -r requirements/test.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
+psutil==6.0.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -491,7 +570,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/test.txt
     #   django-rest-swagger
@@ -536,19 +615,11 @@ text-unidecode==1.3
     # via
     #   -r requirements/test.txt
     #   python-slugify
-tomli==2.0.1
-    # via
-    #   -r requirements/test.txt
-    #   black
-    #   pylint
-    #   pyproject-api
-    #   pytest
-    #   tox
-tomlkit==0.12.4
+tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.15.0
+tox==4.18.0
     # via -r requirements/test.txt
 typing-extensions==4.11.0
     # via

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -54,7 +54,7 @@ requests==2.31.0
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
 sphinx==6.2.1
     # via

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.43.0
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.0
     # via -r requirements/pip.in
-setuptools==69.5.1
+setuptools==72.2.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -27,9 +27,9 @@ backports-zoneinfo==0.2.1 ; python_version < "3.9"
     #   djangorestframework
 bleach==6.1.0
     # via -r requirements/base.txt
-boto3==1.34.99
+boto3==1.34.161
     # via django-ses
-botocore==1.34.99
+botocore==1.34.161
     # via
     #   boto3
     #   s3transfer
@@ -74,7 +74,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/base.txt
 django==4.2.16
     # via
@@ -204,9 +204,70 @@ fontawesomefree==6.5.1
     # via -r requirements/base.txt
 gevent==24.2.1
     # via -r requirements/production.in
+google-api-core[grpc]==2.19.1
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.141.0
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-auth==2.33.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-python-client
+google-cloud-core==2.4.1
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.17.2
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-cloud-storage==2.18.2
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-crc32c==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.63.2
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   grpcio-status
 greenlet==3.0.3
     # via gevent
-gunicorn==22.0.0
+grpcio==1.65.4
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.65.4
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+gunicorn==23.0.0
     # via -r requirements/production.in
 idna==3.7
     # via
@@ -289,7 +350,20 @@ polib==1.2.0
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
-psutil==5.9.8
+proto-plus==1.24.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==5.27.3
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
+psutil==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -380,7 +454,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -91,7 +91,7 @@ defusedxml==0.8.0rc2
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.2
+didkit==0.3.3
     # via -r requirements/base.txt
 dill==0.3.8
     # via pylint
@@ -231,6 +231,72 @@ filelock==3.14.0
     #   virtualenv
 fontawesomefree==6.5.1
     # via -r requirements/base.txt
+google-api-core[grpc]==2.19.1
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+    #   google-api-python-client
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-api-python-client==2.141.0
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-auth==2.33.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-api-python-client
+    #   google-auth-httplib2
+    #   google-cloud-core
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-auth-httplib2==0.2.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-python-client
+google-cloud-core==2.4.1
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-firestore
+    #   google-cloud-storage
+google-cloud-firestore==2.17.2
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-cloud-storage==2.18.2
+    # via
+    #   -r requirements/base.txt
+    #   firebase-admin
+google-crc32c==1.5.0
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.7.2
+    # via
+    #   -r requirements/base.txt
+    #   google-cloud-storage
+googleapis-common-protos==1.63.2
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio==1.65.4
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   grpcio-status
+grpcio-status==1.65.4
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+httplib2==0.22.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-python-client
+    #   google-auth-httplib2
 httpretty==1.1.4
     # via -r requirements/test.in
 idna==3.7
@@ -332,7 +398,20 @@ polib==1.2.0
     # via
     #   -r requirements/base.txt
     #   edx-i18n-tools
-psutil==5.9.8
+proto-plus==1.24.0
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-cloud-firestore
+protobuf==5.27.3
+    # via
+    #   -r requirements/base.txt
+    #   google-api-core
+    #   google-cloud-firestore
+    #   googleapis-common-protos
+    #   grpcio-status
+    #   proto-plus
+psutil==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -445,7 +524,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.19.2
+simplejson==3.19.3
     # via
     #   -r requirements/base.txt
     #   django-rest-swagger
@@ -489,16 +568,9 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-tomli==2.0.1
-    # via
-    #   black
-    #   pylint
-    #   pyproject-api
-    #   pytest
-    #   tox
-tomlkit==0.12.4
+tomlkit==0.13.2
     # via pylint
-tox==4.15.0
+tox==4.18.0
     # via -r requirements/test.in
 typing-extensions==4.11.0
     # via


### PR DESCRIPTION
- The maintainers of `didkit` have released an update that fixes an issue where it would not build on arm64-based systems. This resolves an issue with Devstack and developers running devstack on Apple silicon-based machines.
- this [fix](https://github.com/openedx/credentials/pull/2546) is already merged in master, backporting this fix to work with redwood.