### PR TITLE
fix: add constraint on edx-django-utils

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,3 +23,9 @@ backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo availabl
 # Release notes: https://pypi.org/project/lxml/5.2.0/
 # Github issue: https://github.com/openedx/i18n-tools/issues/144
 lxml<5.2
+
+# Pinning edx-django-utils to <6 
+# v6 drops support for python versions <3.12
+# Changelog: https://github.com/openedx/edx-django-utils/blob/master/CHANGELOG.rst#600---2024-10-09
+# Github issue: https://github.com/openedx/credentials/issues/2569
+edx-django-utils<6


### PR DESCRIPTION
Adding a constraint while we wait for Python 3.12 upgrade

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
