### PR TITLE
fix:  fixing the failing readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,4 +20,4 @@ python:
   install:
   - requirements: requirements/docs.txt
   - method: pip
-    path: credentials
+    path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[project]
+name = "credentials"
+dynamic = ["version"]
+
 [tool.black]
 line-length = 120
 exclude = '(node_modules|private.py|migrations)'
@@ -11,3 +15,6 @@ lines_after_imports = 2
 combine_as_imports = true
 skip = ["migrations", "settings"]
 include_trailing_comma = true
+
+[tool.setuptools]
+packages = ["credentials"]


### PR DESCRIPTION
Adds enough package information to pyproject.toml to allow setuptools to cope with the multiple top-level directories.

* (cherry picked from commit 473a434b192257356c52faa44dda4946e3f29ff3)
* original PR on `master` #2634 

FIXES: APER-3700
