### PR TITLE
feat!: remove mock toggle endpoint

### DIFF
--- a/credentials/urls.py
+++ b/credentials/urls.py
@@ -32,7 +32,7 @@ from credentials.apps.core import views as core_views
 from credentials.apps.plugins.constants import PROJECT_TYPE
 from credentials.apps.records.views import ProgramListingView
 from credentials.apps.verifiable_credentials.toggles import is_verifiable_credentials_enabled
-from credentials.views import FaviconView, MockToggleStateView
+from credentials.views import FaviconView
 
 
 admin.autodiscover()
@@ -65,7 +65,6 @@ urlpatterns = oauth2_urlpatterns + [
     path("records/", include(("credentials.apps.records.urls", "records"), namespace="records")),
     re_path(r"^program-listing/", ProgramListingView.as_view(), name="program_listing"),
     re_path(r"^favicon\.ico$", FaviconView.as_view(permanent=True)),
-    path("mock-toggles", MockToggleStateView.as_view()),
 ]
 
 if is_verifiable_credentials_enabled():

--- a/credentials/views.py
+++ b/credentials/views.py
@@ -1,10 +1,5 @@
 from django.conf import settings
 from django.views.generic.base import RedirectView
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
-from edx_rest_framework_extensions.permissions import IsStaff
-from rest_framework import permissions, views
-from rest_framework.authentication import SessionAuthentication
-from rest_framework.response import Response
 
 
 class FaviconView(RedirectView):
@@ -16,41 +11,3 @@ class FaviconView(RedirectView):
         if not settings.FAVICON_URL:
             return None
         return settings.FAVICON_URL
-
-
-class MockToggleStateView(views.APIView):  # pragma: no cover
-    """
-    A mock endpoint showing that we can require a staff JWT in this IDA,
-    and allowing us to test integration of multiple IDAs into toggle state
-    reports (ARCHBOM-1569). This can go away once edx-toggles is ready and
-    integrated.
-    """
-
-    authentication_classes = (
-        JwtAuthentication,
-        SessionAuthentication,
-    )
-    permission_classes = (
-        permissions.IsAuthenticated,
-        IsStaff,
-    )
-
-    def get(self, request):
-        return Response(
-            {
-                "waffle_flags": [
-                    {
-                        "name": "mock.flag",
-                        "class": "WaffleFlag",
-                        "module": "mock.core.djangoapps.fake",
-                        "code_owner": "platform-arch",
-                        "computed_status": "off",
-                    }
-                ],
-                "waffle_switches": [],
-                "django_settings": [
-                    {"name": "MOCK_DEBUG", "is_active": False},
-                    {"name": "OTHER_MOCK['stuff']", "is_active": True},
-                ],
-            }
-        )


### PR DESCRIPTION
The `mock-toggles` REST endpoint was used for testing a feature used by 2U for collecting the configuration of settings in OeX IDAs. The feature was never fully implemented in Credentials and this endpoint is no longer being used, so we are removing it.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
