### PR TITLE
chore: remove urllib3 constraint

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -867,9 +867,8 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.20
+urllib3==2.2.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   botocore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -402,10 +402,8 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.20
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
+urllib3==2.2.3
+    # via requests
 walrus==0.9.4
     # via edx-event-bus-redis
 webencodings==0.5.1

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,20 +11,12 @@
 # Common constraints for edx repos
 -c common_constraints.txt
 
-# Pinning urllib3 to versions < 2.x as this conflicts with boto. This constraint will be re-evaluated as part of
-# APER-2422
-urllib3<2
-
-
-# Temporary to Support the python 3.11 Upgrade
-backports.zoneinfo;python_version<"3.9"  # Newer versions have zoneinfo available in the standard library
-
 # Pinning lxml to < 5.2 as edx-i18n-tools package needs to be updated.
 # Release notes: https://pypi.org/project/lxml/5.2.0/
 # Github issue: https://github.com/openedx/i18n-tools/issues/144
 lxml<5.2
 
-# Pinning edx-django-utils to <6 
+# Pinning edx-django-utils to <6
 # v6 drops support for python versions <3.12
 # Changelog: https://github.com/openedx/edx-django-utils/blob/master/CHANGELOG.rst#600---2024-10-09
 # Github issue: https://github.com/openedx/credentials/issues/2569

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -678,9 +678,8 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.20
+urllib3==2.2.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   requests
     #   responses

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -69,7 +69,5 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 typing-extensions==4.12.2
     # via pydata-sphinx-theme
-urllib3==1.26.20
-    # via
-    #   -c requirements/constraints.txt
-    #   requests
+urllib3==2.2.3
+    # via requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/credentials/credentials/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
 setuptools==75.6.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -551,9 +551,8 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.20
+urllib3==2.2.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   botocore
     #   requests

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -622,9 +622,8 @@ uritemplate==4.1.1
     #   coreapi
     #   drf-yasg
     #   google-api-python-client
-urllib3==1.26.20
+urllib3==2.2.3
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   requests
     #   responses


### PR DESCRIPTION
Removing the constraint on `urllib3` no longer downgrades boto and its dependencies. I think it is safe to remove this constraint now.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
