### PR TITLE
chore: remove `lxml` constraint

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -33,11 +33,11 @@ bleach==6.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.35.73
+boto3==1.35.74
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.35.73
+botocore==1.35.74
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -492,13 +492,18 @@ jmespath==1.0.1
     #   -r requirements/production.txt
     #   boto3
     #   botocore
-lxml[html-clean]==5.1.1
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-credentials-themes
     #   edx-i18n-tools
+    #   lxml-html-clean
+lxml-html-clean==0.4.1
+    # via
+    #   -r requirements/dev.txt
+    #   -r requirements/production.txt
+    #   lxml
 markdown==3.7
     # via
     #   -r requirements/dev.txt

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -239,11 +239,13 @@ jinja2==3.1.4
     # via
     #   code-annotations
     #   coreschema
-lxml[html-clean,html_clean]==5.1.1
+lxml[html-clean,html_clean]==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   edx-credentials-themes
     #   edx-i18n-tools
+    #   lxml-html-clean
+lxml-html-clean==0.4.1
+    # via lxml
 markdown==3.7
     # via -r requirements/base.in
 markupsafe==3.0.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,11 +11,6 @@
 # Common constraints for edx repos
 -c common_constraints.txt
 
-# Pinning lxml to < 5.2 as edx-i18n-tools package needs to be updated.
-# Release notes: https://pypi.org/project/lxml/5.2.0/
-# Github issue: https://github.com/openedx/i18n-tools/issues/144
-lxml<5.2
-
 # Pinning edx-django-utils to <6
 # v6 drops support for python versions <3.12
 # Changelog: https://github.com/openedx/edx-django-utils/blob/master/CHANGELOG.rst#600---2024-10-09

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -372,12 +372,16 @@ jinja2==3.1.4
     #   -r requirements/test.txt
     #   code-annotations
     #   coreschema
-lxml[html-clean]==5.1.1
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   edx-credentials-themes
     #   edx-i18n-tools
+    #   lxml-html-clean
+lxml-html-clean==0.4.1
+    # via
+    #   -r requirements/test.txt
+    #   lxml
 markdown==3.7
     # via -r requirements/test.txt
 markupsafe==3.0.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,9 +20,9 @@ backoff==2.2.1
     #   segment-analytics-python
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.35.73
+boto3==1.35.74
     # via django-ses
-botocore==1.35.73
+botocore==1.35.74
     # via
     #   boto3
     #   s3transfer
@@ -321,12 +321,16 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-lxml[html-clean]==5.1.1
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-credentials-themes
     #   edx-i18n-tools
+    #   lxml-html-clean
+lxml-html-clean==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   lxml
 markdown==3.7
     # via -r requirements/base.txt
 markupsafe==3.0.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -345,12 +345,16 @@ jinja2==3.1.4
     #   -r requirements/base.txt
     #   code-annotations
     #   coreschema
-lxml[html-clean]==5.1.1
+lxml[html-clean]==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-credentials-themes
     #   edx-i18n-tools
+    #   lxml-html-clean
+lxml-html-clean==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   lxml
 markdown==3.7
     # via -r requirements/base.txt
 markupsafe==3.0.2

--- a/requirements/translations.txt
+++ b/requirements/translations.txt
@@ -12,10 +12,12 @@ django==4.2.16
     #   edx-i18n-tools
 edx-i18n-tools==1.6.3
     # via -r requirements/translations.in
-lxml[html-clean,html_clean]==5.1.1
+lxml[html-clean,html_clean]==5.3.0
     # via
-    #   -c requirements/constraints.txt
     #   edx-i18n-tools
+    #   lxml-html-clean
+lxml-html-clean==0.4.1
+    # via lxml
 path==16.16.0
     # via edx-i18n-tools
 polib==1.2.0


### PR DESCRIPTION
The `edx-i18n-tools` package has been upgraded and we no longer need this constraint.

Relevant `edx-i18n-tools` PR: https://github.com/openedx/i18n-tools/pull/146.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
