### PR TITLE
chore: fixing the stubs in the settings file for the log formatter

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -406,7 +406,8 @@ ACE_CHANNEL_TRANSACTIONAL_EMAIL = "django_email"
 ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME = ""  # unused, but required to be set or we see an exception
 
 # Set up logging for development use (logging to stdout)
-LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel="DEBUG")
+LOGGING_FORMAT_STRING = ""
+LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 
 # DRF Settings
 REST_FRAMEWORK = {

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -8,7 +8,8 @@ DEBUG = str2bool(os.environ.get("DEBUG", True))
 
 ALLOWED_HOSTS = ["*"]
 
-LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel="DEBUG")
+LOGGING_FORMAT_STRING = ""
+LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 del LOGGING["handlers"]["local"]
 
 SECRET_KEY = os.environ.get("SECRET_KEY", "change-me")

--- a/credentials/settings/local.py
+++ b/credentials/settings/local.py
@@ -56,7 +56,8 @@ PROGRAMS_CACHE_TTL = 60
 USER_CACHE_TTL = 60
 
 # LOGGING
-LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel="DEBUG")
+LOGGING_FORMAT_STRING = ""
+LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 
 #####################################################################
 # Lastly, see if the developer has any local overrides.

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -10,7 +10,8 @@ INSTALLED_APPS += [
     "credentials.apps.edx_credentials_extensions",
 ]
 
-LOGGING = get_logger_config(debug=False, dev_env=True, local_loglevel="DEBUG")
+LOGGING_FORMAT_STRING = ""
+LOGGING = get_logger_config(debug=False, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 ALLOWED_HOSTS = ["*"]
 
 DATABASES = {


### PR DESCRIPTION
this is an attempt to fix the overrides for the log formatter by putting stubs in the settings files.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
