### PR TITLE
feat: attempting a new fix for the local log format problem

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -406,7 +406,7 @@ ACE_CHANNEL_TRANSACTIONAL_EMAIL = "django_email"
 ACE_CHANNEL_SAILTHRU_TEMPLATE_NAME = ""  # unused, but required to be set or we see an exception
 
 # Set up logging for development use (logging to stdout)
-LOGGING_FORMAT_STRING = ""
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
 LOGGING = get_logger_config(debug=DEBUG, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 
 # DRF Settings

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -8,7 +8,7 @@ DEBUG = str2bool(os.environ.get("DEBUG", True))
 
 ALLOWED_HOSTS = ["*"]
 
-LOGGING_FORMAT_STRING = ""
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
 LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 del LOGGING["handlers"]["local"]
 

--- a/credentials/settings/local.py
+++ b/credentials/settings/local.py
@@ -56,7 +56,7 @@ PROGRAMS_CACHE_TTL = 60
 USER_CACHE_TTL = 60
 
 # LOGGING
-LOGGING_FORMAT_STRING = ""
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
 LOGGING = get_logger_config(debug=True, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 
 #####################################################################

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -10,7 +10,7 @@ INSTALLED_APPS += [
     "credentials.apps.edx_credentials_extensions",
 ]
 
-LOGGING_FORMAT_STRING = ""
+LOGGING_FORMAT_STRING = os.environ.get("LOGGING_FORMAT_STRING", "")
 LOGGING = get_logger_config(debug=False, dev_env=True, local_loglevel="DEBUG", format_string=LOGGING_FORMAT_STRING)
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
The previous attempt to set a local log format failed because first the base configuration files are applied, in which the logging format is set via a function call, and then our own internal overrides are applied. Basically, there's a timing problem.

This is an attempt to solve that problem in the hopes that the environment variables are set before the configuration files for the application are run. This change will be made in conjunction with an internal config PR.

FIXES: APER-3805
