### PR TITLE
chore: fix timing issue with logging overrides

### DIFF
--- a/credentials/settings/production.py
+++ b/credentials/settings/production.py
@@ -12,9 +12,6 @@ TEMPLATE_DEBUG = DEBUG
 
 ALLOWED_HOSTS = ["*"]
 
-LOGGING_FORMAT_STRING = ""
-LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
-
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
 DICT_UPDATE_KEYS = ("JWT_AUTH",)
@@ -49,6 +46,9 @@ with open(CONFIG_FILE, encoding="utf-8") as f:
 
     # Load the files storage backend settings for django storages
     vars().update(FILE_STORAGE_BACKEND)
+
+# make sure this happens after the configuration file overrides so format string can be overridden
+LOGGING = get_logger_config(format_string=LOGGING_FORMAT_STRING)
 
 if "EXTRA_APPS" in locals():
     INSTALLED_APPS += EXTRA_APPS


### PR DESCRIPTION
Make sure that the call to `get_logger`  happens after the configuration file overrides have a chance to set `LOGGING_FORMAT_STRING`.

FIXES: APER-3805

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
