### PR TITLE
refactor: update deprecated requestmetric middleware

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -105,7 +105,7 @@ MIDDLEWARE = (
     "waffle.middleware.WaffleMiddleware",
     "django_ratelimit.middleware.RatelimitMiddleware",
     "edx_django_utils.cache.middleware.TieredCacheMiddleware",
-    "edx_rest_framework_extensions.middleware.RequestMetricsMiddleware",
+    "edx_rest_framework_extensions.middleware.RequestCustomAttributesMiddleware",
     "edx_rest_framework_extensions.auth.jwt.middleware.EnsureJWTAuthSettingsMiddleware",
     "crum.CurrentRequestUserMiddleware",
 )


### PR DESCRIPTION
## Description
- PR created under the issue https://github.com/edx/edx-arch-experiments/issues/815
- The middleware was [deprecated/renamed](https://github.com/openedx/edx-drf-extensions/blob/2b4347518680046aa54caa404c030d0ffe308acf/CHANGELOG.rst#620---2020-08-24) in the `edx-drf-extensions==6.2.0` but was pending to be updated.