### PR TITLE
chore: downgrading python in ci  for consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
           architecture: x64
       - name: Install Dependencies
         run: make requirements


### PR DESCRIPTION
the docs aren't building on github because a valid version of `didkit` won't install, and I think it might be because we upgraded Python to bleeding edge but only for the `ci` workflows.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
