### PR TITLE
fix: fix indentation in the upgrade-python-requirements workflow

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -19,8 +19,8 @@ jobs:
       team_reviewers: "2u-aperture"
       email_address: aperture@2u-internal.opsgenie.net
       send_success_notification: true
-  secrets:
-    requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
-    requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
-    edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
-    edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}
+    secrets:
+      requirements_bot_github_token: ${{ secrets.REQUIREMENTS_BOT_GITHUB_TOKEN }}
+      requirements_bot_github_email: ${{ secrets.REQUIREMENTS_BOT_GITHUB_EMAIL }}
+      edx_smtp_username: ${{ secrets.EDX_SMTP_USERNAME }}
+      edx_smtp_password: ${{ secrets.EDX_SMTP_PASSWORD }}


### PR DESCRIPTION
I was fixing up some spacing/indentation in this workflow and accidentally de-dented the `secrets` portion of the job too far.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
