### PR TITLE
chore: remove constraint on edx-django-utils

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -33,11 +33,11 @@ bleach==6.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.37.19
+boto3==1.37.23
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.37.19
+botocore==1.37.23
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -107,7 +107,7 @@ coreschema==0.0.4
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   coreapi
-coverage==7.7.1
+coverage==7.8.0
     # via -r requirements/dev.txt
 cryptography==44.0.2
     # via
@@ -254,7 +254,7 @@ django-webpack-loader==3.1.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -302,9 +302,8 @@ edx-django-sites-extensions==4.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-django-utils==5.16.0
+edx-django-utils==7.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   django-config-models
@@ -387,7 +386,7 @@ google-api-core[grpc]==2.24.2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.165.0
+google-api-python-client==2.166.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -423,7 +422,7 @@ google-cloud-storage==3.1.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   firebase-admin
-google-crc32c==1.7.0
+google-crc32c==1.7.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -540,7 +539,7 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-newrelic==10.7.0
+newrelic==10.8.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -639,7 +638,7 @@ pyasn1==0.6.1
     #   -r requirements/production.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -856,13 +855,13 @@ tomlkit==0.13.2
     # via
     #   -r requirements/dev.txt
     #   pylint
-tox==4.24.2
+tox==4.25.0
     # via -r requirements/dev.txt
-types-pyyaml==6.0.12.20241230
+types-pyyaml==6.0.12.20250326
     # via
     #   -r requirements/dev.txt
     #   django-stubs
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -889,7 +888,7 @@ urllib3==2.2.3
     #   botocore
     #   requests
     #   responses
-virtualenv==20.29.3
+virtualenv==20.30.0
     # via
     #   -r requirements/dev.txt
     #   tox

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -122,7 +122,7 @@ django-waffle==4.2.0
     #   edx-toggles
 django-webpack-loader==3.1.1
     # via -r requirements/base.in
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -148,9 +148,8 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.in
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.in
-edx-django-utils==5.16.0
+edx-django-utils==7.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-config-models
     #   edx-ace
@@ -194,7 +193,7 @@ google-api-core[grpc]==2.24.2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.165.0
+google-api-python-client==2.166.0
     # via firebase-admin
 google-auth==2.38.0
     # via
@@ -214,7 +213,7 @@ google-cloud-firestore==2.20.1
     # via firebase-admin
 google-cloud-storage==3.1.0
     # via firebase-admin
-google-crc32c==1.7.0
+google-crc32c==1.7.1
     # via
     #   google-cloud-storage
     #   google-resumable-media
@@ -259,7 +258,7 @@ msgpack==1.1.0
     # via cachecontrol
 mysqlclient==2.2.7
     # via -r requirements/base.in
-newrelic==10.7.0
+newrelic==10.8.0
     # via
     #   -r requirements/base.in
     #   edx-django-utils
@@ -303,7 +302,7 @@ pyasn1==0.6.1
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.22
     # via cffi
@@ -402,7 +401,7 @@ stevedore==5.4.1
     #   edx-opaque-keys
 text-unidecode==1.3
     # via python-slugify
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via edx-opaque-keys
 uritemplate==4.1.1
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,9 +10,3 @@
 
 # Common constraints for edx repos
 -c common_constraints.txt
-
-# Pinning edx-django-utils to <6
-# v6 drops support for python versions <3.12
-# Changelog: https://github.com/openedx/edx-django-utils/blob/master/CHANGELOG.rst#600---2024-10-09
-# Github issue: https://github.com/openedx/credentials/issues/2569
-edx-django-utils<6

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -84,7 +84,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage==7.7.1
+coverage==7.8.0
     # via -r requirements/test.txt
 cryptography==44.0.2
     # via
@@ -193,7 +193,7 @@ django-waffle==4.2.0
     #   edx-toggles
 django-webpack-loader==3.1.1
     # via -r requirements/test.txt
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -225,9 +225,8 @@ edx-django-release-util==1.4.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.16.0
+edx-django-utils==7.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   django-config-models
     #   edx-ace
@@ -292,7 +291,7 @@ google-api-core[grpc]==2.24.2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.165.0
+google-api-python-client==2.166.0
     # via
     #   -r requirements/test.txt
     #   firebase-admin
@@ -322,7 +321,7 @@ google-cloud-storage==3.1.0
     # via
     #   -r requirements/test.txt
     #   firebase-admin
-google-crc32c==1.7.0
+google-crc32c==1.7.1
     # via
     #   -r requirements/test.txt
     #   google-cloud-storage
@@ -410,7 +409,7 @@ mypy-extensions==1.0.0
     #   mypy
 mysqlclient==2.2.7
     # via -r requirements/test.txt
-newrelic==10.7.0
+newrelic==10.8.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -490,7 +489,7 @@ pyasn1==0.6.1
     #   -r requirements/test.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via
     #   -r requirements/test.txt
     #   google-auth
@@ -668,11 +667,11 @@ tomlkit==0.13.2
     # via
     #   -r requirements/test.txt
     #   pylint
-tox==4.24.2
+tox==4.25.0
     # via -r requirements/test.txt
-types-pyyaml==6.0.12.20241230
+types-pyyaml==6.0.12.20250326
     # via django-stubs
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/test.txt
     #   django-stubs
@@ -695,7 +694,7 @@ urllib3==2.2.3
     #   -r requirements/test.txt
     #   requests
     #   responses
-virtualenv==20.29.3
+virtualenv==20.30.0
     # via
     #   -r requirements/test.txt
     #   tox

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -71,7 +71,7 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   beautifulsoup4
     #   pydata-sphinx-theme

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/credentials/credentials/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==78.0.2
+setuptools==78.1.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,9 +20,9 @@ backoff==2.2.1
     #   segment-analytics-python
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.37.19
+boto3==1.37.23
     # via django-ses
-botocore==1.37.19
+botocore==1.37.23
     # via
     #   boto3
     #   s3transfer
@@ -156,7 +156,7 @@ django-waffle==4.2.0
     #   edx-toggles
 django-webpack-loader==3.1.1
     # via -r requirements/base.txt
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -188,9 +188,8 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.16.0
+edx-django-utils==7.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-config-models
     #   edx-ace
@@ -243,7 +242,7 @@ google-api-core[grpc]==2.24.2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.165.0
+google-api-python-client==2.166.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
@@ -273,7 +272,7 @@ google-cloud-storage==3.1.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
-google-crc32c==1.7.0
+google-crc32c==1.7.1
     # via
     #   -r requirements/base.txt
     #   google-cloud-storage
@@ -348,7 +347,7 @@ msgpack==1.1.0
     #   cachecontrol
 mysqlclient==2.2.7
     # via -r requirements/base.txt
-newrelic==10.7.0
+newrelic==10.8.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
@@ -412,7 +411,7 @@ pyasn1==0.6.1
     #   -r requirements/base.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -550,7 +549,7 @@ text-unidecode==1.3
     # via
     #   -r requirements/base.txt
     #   python-slugify
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -77,7 +77,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage==7.7.1
+coverage==7.8.0
     # via -r requirements/test.in
 cryptography==44.0.2
     # via
@@ -172,7 +172,7 @@ django-waffle==4.2.0
     #   edx-toggles
 django-webpack-loader==3.1.1
     # via -r requirements/base.txt
-djangorestframework==3.15.2
+djangorestframework==3.16.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -204,9 +204,8 @@ edx-django-release-util==1.4.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==4.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.16.0
+edx-django-utils==7.2.0
     # via
-    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-config-models
     #   edx-ace
@@ -267,7 +266,7 @@ google-api-core[grpc]==2.24.2
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
-google-api-python-client==2.165.0
+google-api-python-client==2.166.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
@@ -297,7 +296,7 @@ google-cloud-storage==3.1.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
-google-crc32c==1.7.0
+google-crc32c==1.7.1
     # via
     #   -r requirements/base.txt
     #   google-cloud-storage
@@ -376,7 +375,7 @@ mypy-extensions==1.0.0
     # via black
 mysqlclient==2.2.7
     # via -r requirements/base.txt
-newrelic==10.7.0
+newrelic==10.8.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -452,7 +451,7 @@ pyasn1==0.6.1
     #   -r requirements/base.txt
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.4.2
     # via
     #   -r requirements/base.txt
     #   google-auth
@@ -617,9 +616,9 @@ text-unidecode==1.3
     #   python-slugify
 tomlkit==0.13.2
     # via pylint
-tox==4.24.2
+tox==4.25.0
     # via -r requirements/test.in
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -637,7 +636,7 @@ urllib3==2.2.3
     #   -r requirements/base.txt
     #   requests
     #   responses
-virtualenv==20.29.3
+virtualenv==20.30.0
     # via tox
 walrus==0.9.4
     # via


### PR DESCRIPTION
This constraint is no longer needed now that Credentials supports Python 3.12.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [x] All tests pass
