### PR TITLE
feat: cherry pick FA icons used in Credentials UIs

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -65,7 +65,6 @@ THIRD_PARTY_APPS = [
     "drf_yasg",
     "xss_utils",
     "openedx_events",
-    "fontawesomefree",
 ]
 
 PROJECT_APPS = [

--- a/credentials/static/js/fontawesome.js
+++ b/credentials/static/js/fontawesome.js
@@ -1,0 +1,7 @@
+// for cherry picking only the icons used in the Credentials UI, so that we don't have to import ALL icons from FA
+import { library, dom } from '@fortawesome/fontawesome-svg-core';
+import { faFacebook, faTwitter, faLinkedin } from '@fortawesome/free-brands-svg-icons';
+import { faPrint } from '@fortawesome/free-solid-svg-icons';
+
+library.add(faFacebook, faTwitter, faLinkedin, faPrint);
+dom.watch();

--- a/credentials/templates/base.html
+++ b/credentials/templates/base.html
@@ -16,10 +16,7 @@
     <title>{% block title %}{% endblock title %}</title>
 
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
-    <!-- import fontawesome svgs and icons -->
-    <script src="{% static 'fontawesomefree/js/fontawesome.js' %}"></script>
-    <script src="{% static 'fontawesomefree/js/solid.js' %}"></script>
-    <script src="{% static 'fontawesomefree/js/brands.js' %}"></script>
+    {% render_bundle 'fontawesome' 'js' %}
 
     {% if base_style_template %}
       {% include base_style_template %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
       "name": "edx-credentials",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.7.2",
+        "@fortawesome/free-brands-svg-icons": "^6.7.2",
+        "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "@openedx/paragon": "^23.3.1",
         "bi-app-sass": "1.1.0",
         "css-loader": "7.1.2",
@@ -2116,6 +2119,47 @@
       "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+      "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
+      "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-zu0evbcRTgjKfrr77/2XX+bU+kuGfjm0LbajJHVIgBWNIDzrhpRxiCPNT8DW5AdmSsq7Mcf9D1bH0aSeSUSM+Q==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+      "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.2"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "lint": "eslint --ext .js --ext .jsx ./credentials/static"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.7.2",
+    "@fortawesome/free-brands-svg-icons": "^6.7.2",
+    "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "@openedx/paragon": "^23.3.1",
     "bi-app-sass": "1.1.0",
     "css-loader": "7.1.2",

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -127,7 +127,7 @@ didkit==0.3.3
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-dill==0.3.9
+dill==0.4.0
     # via
     #   -r requirements/dev.txt
     #   pylint
@@ -371,10 +371,6 @@ firebase-admin==6.7.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   edx-ace
-fontawesomefree==6.6.0
-    # via
-    #   -r requirements/dev.txt
-    #   -r requirements/production.txt
 gevent==24.11.1
     # via -r requirements/production.txt
 google-api-core[grpc]==2.24.2
@@ -439,7 +435,7 @@ googleapis-common-protos==1.70.0
     #   -r requirements/production.txt
     #   google-api-core
     #   grpcio-status
-greenlet==3.1.1
+greenlet==3.2.0
     # via
     #   -r requirements/production.txt
     #   gevent
@@ -780,7 +776,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 responses==0.25.7
     # via -r requirements/dev.txt
-rsa==4.9
+rsa==4.9.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -38,7 +38,6 @@ edx-event-bus-kafka
 edx-opaque-keys
 edx-rest-api-client
 edx-toggles
-fontawesomefree
 markdown
 mysqlclient
 newrelic

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -184,8 +184,6 @@ fastavro==1.10.0
     # via openedx-events
 firebase-admin==6.7.0
     # via edx-ace
-fontawesomefree==6.6.0
-    # via -r requirements/base.in
 google-api-core[grpc]==2.24.2
     # via
     #   firebase-admin
@@ -364,7 +362,7 @@ requests==2.32.3
     #   social-auth-core
 requests-oauthlib==2.0.0
     # via social-auth-core
-rsa==4.9
+rsa==4.9.1
     # via google-auth
 sailthru-client==2.2.3
     # via edx-ace

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -100,7 +100,7 @@ defusedxml==0.7.1
     #   social-auth-core
 didkit==0.3.3
     # via -r requirements/test.txt
-dill==0.3.9
+dill==0.4.0
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -281,8 +281,6 @@ firebase-admin==6.7.0
     # via
     #   -r requirements/test.txt
     #   edx-ace
-fontawesomefree==6.6.0
-    # via -r requirements/test.txt
 google-api-core[grpc]==2.24.2
     # via
     #   -r requirements/test.txt
@@ -608,7 +606,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 responses==0.25.7
     # via -r requirements/test.txt
-rsa==4.9
+rsa==4.9.1
     # via
     #   -r requirements/test.txt
     #   google-auth

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -12,7 +12,7 @@ babel==2.17.0
     # via
     #   pydata-sphinx-theme
     #   sphinx
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
 certifi==2025.1.31
     # via requests

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/credentials/credentials/requirements/common_constraints.txt
+    #   -c /edx/app/credentials/credentials/requirements/common_constraints.txt
     #   -r requirements/pip.in
 setuptools==78.1.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -230,8 +230,6 @@ firebase-admin==6.7.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
-fontawesomefree==6.6.0
-    # via -r requirements/base.txt
 gevent==24.11.1
     # via -r requirements/production.in
 google-api-core[grpc]==2.24.2
@@ -286,7 +284,7 @@ googleapis-common-protos==1.70.0
     #   -r requirements/base.txt
     #   google-api-core
     #   grpcio-status
-greenlet==3.1.1
+greenlet==3.2.0
     # via gevent
 grpcio==1.71.0
     # via
@@ -496,7 +494,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/base.txt
     #   social-auth-core
-rsa==4.9
+rsa==4.9.1
     # via
     #   -r requirements/base.txt
     #   google-auth

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -93,7 +93,7 @@ defusedxml==0.7.1
     #   social-auth-core
 didkit==0.3.3
     # via -r requirements/base.txt
-dill==0.3.9
+dill==0.4.0
     # via pylint
 distlib==0.3.9
     # via virtualenv
@@ -256,8 +256,6 @@ firebase-admin==6.7.0
     # via
     #   -r requirements/base.txt
     #   edx-ace
-fontawesomefree==6.6.0
-    # via -r requirements/base.txt
 google-api-core[grpc]==2.24.2
     # via
     #   -r requirements/base.txt
@@ -560,7 +558,7 @@ requests-oauthlib==2.0.0
     #   social-auth-core
 responses==0.25.7
     # via -r requirements/test.in
-rsa==4.9
+rsa==4.9.1
     # via
     #   -r requirements/base.txt
     #   google-auth

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
     'openedx.certificate.style-rtl': './credentials/apps/credentials_theme_openedx/static/sass/certificate-rtl.scss',
     sharing: './credentials/static/js/sharing.js',
     analytics: './credentials/static/js/analytics.js',
+    fontawesome: './credentials/static/js/fontawesome.js',
   },
   output: {
     path: path.resolve('./credentials/static/bundles/'),


### PR DESCRIPTION
Previous to this change, when collecting static assets, we would include ALL of the FA icons. This PR is an attempt to limit the icons in our bundle to only the icons used in the UI.

As part of this change, the `fontawesomefree` app is no longer needed, so it has been removed.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
