### PR TITLE
feat: Remove newrelic package from base dependencies

### DIFF
--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -535,10 +535,6 @@ mysqlclient==2.2.7
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-newrelic==10.12.0
-    # via
-    #   -r requirements/dev.txt
-    #   -r requirements/production.txt
 nodeenv==1.9.1
     # via -r requirements/production.txt
 oauthlib==3.2.2

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -33,11 +33,11 @@ bleach==6.2.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-boto3==1.38.19
+boto3==1.38.22
     # via
     #   -r requirements/production.txt
     #   django-ses
-botocore==1.38.19
+botocore==1.38.22
     # via
     #   -r requirements/production.txt
     #   boto3
@@ -73,7 +73,7 @@ charset-normalizer==3.4.2
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   requests
-click==8.2.0
+click==8.2.1
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -107,7 +107,7 @@ coreschema==0.0.4
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   coreapi
-coverage==7.8.0
+coverage==7.8.1
     # via -r requirements/dev.txt
 cryptography==45.0.2
     # via
@@ -302,7 +302,7 @@ edx-django-sites-extensions==5.1.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -387,7 +387,7 @@ google-api-python-client==2.169.0
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   firebase-admin
-google-auth==2.40.1
+google-auth==2.40.2
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
@@ -539,7 +539,6 @@ newrelic==10.12.0
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
-    #   edx-django-utils
 nodeenv==1.9.1
     # via -r requirements/production.txt
 oauthlib==3.2.2
@@ -781,7 +780,7 @@ rsa==4.9.1
     #   -r requirements/dev.txt
     #   -r requirements/production.txt
     #   google-auth
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via
     #   -r requirements/production.txt
     #   boto3

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -40,7 +40,6 @@ edx-rest-api-client
 edx-toggles
 markdown
 mysqlclient
-newrelic
 openedx-atlas
 openedx-events
 pillow

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -256,8 +256,6 @@ msgpack==1.1.0
     # via cachecontrol
 mysqlclient==2.2.7
     # via -r requirements/base.in
-newrelic==10.12.0
-    # via -r requirements/base.in
 oauthlib==3.2.2
     # via
     #   requests-oauthlib

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -28,7 +28,7 @@ cffi==1.17.1
     #   pynacl
 charset-normalizer==3.4.2
     # via requests
-click==8.2.0
+click==8.2.1
     # via
     #   code-annotations
     #   edx-django-utils
@@ -148,7 +148,7 @@ edx-django-release-util==1.5.0
     # via -r requirements/base.in
 edx-django-sites-extensions==5.1.0
     # via -r requirements/base.in
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -193,7 +193,7 @@ google-api-core[grpc]==2.24.2
     #   google-cloud-storage
 google-api-python-client==2.169.0
     # via firebase-admin
-google-auth==2.40.1
+google-auth==2.40.2
     # via
     #   google-api-core
     #   google-api-python-client
@@ -257,9 +257,7 @@ msgpack==1.1.0
 mysqlclient==2.2.7
     # via -r requirements/base.in
 newrelic==10.12.0
-    # via
-    #   -r requirements/base.in
-    #   edx-django-utils
+    # via -r requirements/base.in
 oauthlib==3.2.2
     # via
     #   requests-oauthlib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -54,7 +54,7 @@ charset-normalizer==3.4.2
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.2.0
+click==8.2.1
     # via
     #   -r requirements/test.txt
     #   black
@@ -84,7 +84,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/test.txt
     #   coreapi
-coverage==7.8.0
+coverage==7.8.1
     # via -r requirements/test.txt
 cryptography==45.0.2
     # via
@@ -225,7 +225,7 @@ edx-django-release-util==1.5.0
     # via -r requirements/test.txt
 edx-django-sites-extensions==5.1.0
     # via -r requirements/test.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -293,7 +293,7 @@ google-api-python-client==2.169.0
     # via
     #   -r requirements/test.txt
     #   firebase-admin
-google-auth==2.40.1
+google-auth==2.40.2
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -408,9 +408,7 @@ mypy-extensions==1.1.0
 mysqlclient==2.2.7
     # via -r requirements/test.txt
 newrelic==10.12.0
-    # via
-    #   -r requirements/test.txt
-    #   edx-django-utils
+    # via -r requirements/test.txt
 oauthlib==3.2.2
     # via
     #   -r requirements/test.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -407,8 +407,6 @@ mypy-extensions==1.1.0
     #   mypy
 mysqlclient==2.2.7
     # via -r requirements/test.txt
-newrelic==10.12.0
-    # via -r requirements/test.txt
 oauthlib==3.2.2
     # via
     #   -r requirements/test.txt

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,7 +10,7 @@ wheel==0.45.1
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.2
     # via
-    #   -c /home/runner/work/credentials/credentials/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
-setuptools==80.7.1
+setuptools==80.8.0
     # via -r requirements/pip.in

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -6,7 +6,7 @@
 #
 build==1.2.2.post1
     # via pip-tools
-click==8.2.0
+click==8.2.1
     # via pip-tools
 packaging==25.0
     # via build

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -13,6 +13,5 @@
 django-ses
 gevent
 gunicorn
-newrelic
 nodeenv
 PyYAML

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -345,10 +345,6 @@ msgpack==1.1.0
     #   cachecontrol
 mysqlclient==2.2.7
     # via -r requirements/base.txt
-newrelic==10.12.0
-    # via
-    #   -r requirements/base.txt
-    #   -r requirements/production.in
 nodeenv==1.9.1
     # via -r requirements/production.in
 oauthlib==3.2.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -20,9 +20,9 @@ backoff==2.2.1
     #   segment-analytics-python
 bleach==6.2.0
     # via -r requirements/base.txt
-boto3==1.38.19
+boto3==1.38.22
     # via django-ses
-botocore==1.38.19
+botocore==1.38.22
     # via
     #   boto3
     #   s3transfer
@@ -47,7 +47,7 @@ charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.2.0
+click==8.2.1
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -188,7 +188,7 @@ edx-django-release-util==1.5.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==5.1.0
     # via -r requirements/base.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -244,7 +244,7 @@ google-api-python-client==2.169.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
-google-auth==2.40.1
+google-auth==2.40.2
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -349,7 +349,6 @@ newrelic==10.12.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
-    #   edx-django-utils
 nodeenv==1.9.1
     # via -r requirements/production.in
 oauthlib==3.2.2
@@ -498,7 +497,7 @@ rsa==4.9.1
     # via
     #   -r requirements/base.txt
     #   google-auth
-s3transfer==0.12.0
+s3transfer==0.13.0
     # via boto3
 sailthru-client==2.2.3
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -50,7 +50,7 @@ charset-normalizer==3.4.2
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.2.0
+click==8.2.1
     # via
     #   -r requirements/base.txt
     #   black
@@ -77,7 +77,7 @@ coreschema==0.0.4
     # via
     #   -r requirements/base.txt
     #   coreapi
-coverage==7.8.0
+coverage==7.8.1
     # via -r requirements/test.in
 cryptography==45.0.2
     # via
@@ -204,7 +204,7 @@ edx-django-release-util==1.5.0
     # via -r requirements/base.txt
 edx-django-sites-extensions==5.1.0
     # via -r requirements/base.txt
-edx-django-utils==7.4.0
+edx-django-utils==8.0.0
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -268,7 +268,7 @@ google-api-python-client==2.169.0
     # via
     #   -r requirements/base.txt
     #   firebase-admin
-google-auth==2.40.1
+google-auth==2.40.2
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -374,9 +374,7 @@ mypy-extensions==1.1.0
 mysqlclient==2.2.7
     # via -r requirements/base.txt
 newrelic==10.12.0
-    # via
-    #   -r requirements/base.txt
-    #   edx-django-utils
+    # via -r requirements/base.txt
 oauthlib==3.2.2
     # via
     #   -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -373,8 +373,6 @@ mypy-extensions==1.1.0
     # via black
 mysqlclient==2.2.7
     # via -r requirements/base.txt
-newrelic==10.12.0
-    # via -r requirements/base.txt
 oauthlib==3.2.2
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
`newrelic` is not directly used by this repository, and edx-django-utils provides a pluggable telemetry API for any deployers who use New Relic.

See DEPR for details: https://github.com/openedx/public-engineering/issues

This PR is composed of two commits. The first is the result of `make upgrade`, and the second removes `newrelic` from the `.in` files and runs `make upgrade` again (so you can see the actual effect).

----

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [ ] All tests pass
