### PR TITLE
docs: Fix cross-ref bug in badging docs

### DIFF
--- a/docs/badges/configuration/accredible.rst
+++ b/docs/badges/configuration/accredible.rst
@@ -98,7 +98,7 @@ Requirements group is fulfilled if any of its requirements is fulfilled.
 .. image:: ../../_static/images/badges/badges-admin-rules-group.png
         :alt: Badge requirement rules group
 
-See `configuration examples`_.
+See :ref:`Configuration examples for Badging`.
 
 Data Rules
 ----------
@@ -134,7 +134,7 @@ All key paths are generated based on the event type specified for the parent Bad
     - payload boolean negative values allowed: ``"false", "False", "no", "No", "-"``;
 
 
-Please, see `configuration examples`_ for clarity.
+Please, see :ref:`Configuration examples for Badging` for clarity.
 
 Badge Penalties
 ---------------
@@ -169,5 +169,4 @@ Accredible group record includes:
 3. Accredible service attributes (dashboard link);
 4. Configured requirements;
 
-.. _`configuration examples`: examples.html
 .. _openedx-events: https://github.com/openedx/openedx-events

--- a/docs/badges/configuration/credly.rst
+++ b/docs/badges/configuration/credly.rst
@@ -117,7 +117,7 @@ Requirements group is fulfilled if any of its requirements is fulfilled.
 .. image:: ../../_static/images/badges/badges-admin-rules-group.png
         :alt: Badge requirement rules group
 
-See `configuration examples`_.
+See :ref:`Configuration examples for Badging`.
 
 Data Rules
 ----------
@@ -153,7 +153,7 @@ All key paths are generated based on the event type specified for the parent Bad
     - payload boolean negative values allowed: ``"false", "False", "no", "No", "-"``;
 
 
-Please, see `configuration examples`_ for clarity.
+Please, see :ref:`Configuration examples for Badging` for clarity.
 
 Badge Penalties
 ---------------
@@ -191,5 +191,4 @@ Credly badge template record includes:
 3. Credly service attributes (state, dashboard link);
 4. Configured requirements;
 
-.. _`configuration examples`: examples.html
 .. _openedx-events: https://github.com/openedx/openedx-events

--- a/docs/badges/examples.rst
+++ b/docs/badges/examples.rst
@@ -1,3 +1,5 @@
+.. _Configuration examples for Badging:
+
 Configuration examples for Badging
 ===================================
 


### PR DESCRIPTION
Currently the links to the configuration examples are broken in https://docs.openedx.org/projects/edx-credentials/en/latest/badges/configuration/accredible.html and https://docs.openedx.org/projects/edx-credentials/en/latest/badges/configuration/credly.html. This PR fixes the broken links and uses RST best practice (reference links rather than direct filepaths).
