### PR TITLE
django52: remove deprecated DEFAULT_FILE_STORAGE and STATICFILES_STORAGE

### DIFF
--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -456,7 +456,14 @@ CSRF_COOKIE_SECURE = False
 FILE_STORAGE_BACKEND = {}
 EXTRA_APPS = []
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.ManifestStaticFilesStorage"
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage',
+    }
+}
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",

--- a/credentials/settings/base.py
+++ b/credentials/settings/base.py
@@ -457,12 +457,12 @@ FILE_STORAGE_BACKEND = {}
 EXTRA_APPS = []
 SESSION_EXPIRE_AT_BROWSER_CLOSE = False
 STORAGES = {
-    'default': {
-        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
-    'staticfiles': {
-        'BACKEND': 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage',
-    }
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.ManifestStaticFilesStorage",
+    },
 }
 CACHES = {
     "default": {

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -46,7 +46,9 @@ EMAIL_FILE_PATH = "/tmp/credentials-emails"
 STORAGES["default"]["BACKEND"] = os.environ.get("DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
 MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 
-STORAGES["staticfiles"]["BACKEND"] = os.environ.get("STATICFILES_STORAGE", "django.contrib.staticfiles.storage.StaticFilesStorage")
+STORAGES["staticfiles"]["BACKEND"] = os.environ.get(
+    "STATICFILES_STORAGE", "django.contrib.staticfiles.storage.StaticFilesStorage"
+)
 STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 
 # OAuth2 variables specific to social-auth/SSO login use case.

--- a/credentials/settings/devstack.py
+++ b/credentials/settings/devstack.py
@@ -43,10 +43,10 @@ INSTALLED_APPS += ["credentials.apps.edx_credentials_extensions"]
 EMAIL_BACKEND = "django.core.mail.backends.filebased.EmailBackend"
 EMAIL_FILE_PATH = "/tmp/credentials-emails"
 
-DEFAULT_FILE_STORAGE = os.environ.get("DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
+STORAGES["default"]["BACKEND"] = os.environ.get("DEFAULT_FILE_STORAGE", "django.core.files.storage.FileSystemStorage")
 MEDIA_URL = os.environ.get("MEDIA_URL", "/media/")
 
-STATICFILES_STORAGE = os.environ.get("STATICFILES_STORAGE", "django.contrib.staticfiles.storage.StaticFilesStorage")
+STORAGES["staticfiles"]["BACKEND"] = os.environ.get("STATICFILES_STORAGE", "django.contrib.staticfiles.storage.StaticFilesStorage")
 STATIC_URL = os.environ.get("STATIC_URL", "/static/")
 
 # OAuth2 variables specific to social-auth/SSO login use case.

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -49,12 +49,12 @@ JWT_AUTH.update(
     }
 )
 STORAGES = {
-    'default': {
-        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
     },
-    'staticfiles': {
-        'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
-    }
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
 }
 # Verifiable Credentials
 ENABLE_VERIFIABLE_CREDENTIALS = True

--- a/credentials/settings/test.py
+++ b/credentials/settings/test.py
@@ -35,7 +35,6 @@ CACHES = {
 
 # Local Directories
 TEST_ROOT = path("test_root")
-DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 MEDIA_ROOT = str(TEST_ROOT / "uploads")
 MEDIA_URL = "/static/uploads/"
 
@@ -49,8 +48,14 @@ JWT_AUTH.update(
         "JWT_AUDIENCE": SOCIAL_AUTH_EDX_OAUTH2_KEY,
     }
 )
-STATICFILES_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
-
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'django.contrib.staticfiles.storage.StaticFilesStorage',
+    }
+}
 # Verifiable Credentials
 ENABLE_VERIFIABLE_CREDENTIALS = True
 VERIFIABLE_CREDENTIALS = {


### PR DESCRIPTION
Issue:
https://github.com/openedx/credentials/issues/2822

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [x] Make sure you are inside the devstack container
- [x] Run `make test-karma`
- [x] All tests pass
