### PR TITLE
fix: forking work for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [release-ulmo]
   pull_request:
-    branches: [master]
+    branches: [release-ulmo]
 
 jobs:
   quality_and_translations_tests:

--- a/.github/workflows/migrations-mysql8-check.yml
+++ b/.github/workflows/migrations-mysql8-check.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - release-ulmo
 
 jobs:
   check_migrations:

--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -1,15 +1,12 @@
 name: Upgrade Requirements
 
 on:
-  schedule:
-    # will start the job at 13:15 UTC every Tuesday
-    - cron: "15 13 * * 2"
   workflow_dispatch:
     inputs:
       branch:
         description: 'Target branch to create requirements PR against'
         required: true
-        default: 'master'
+        default: 'release-ulmo'
 jobs:
   call-upgrade-python-requirements-workflow:
     uses: openedx/.github/.github/workflows/upgrade-python-requirements.yml@master


### PR DESCRIPTION
per our internal setup documentation:

* Changing the branch for the workflows to match the release branch
* disabling the  timed update workflow which we are no longer handling here

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
