### PR TITLE
fix: pin pip <25.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ requirements: piptools ## Install requirements for local development
 	pip-sync requirements/dev.txt
 
 piptools:
+	pip install -U 'pip<25.3'
 	pip install -q -r requirements/pip_tools.txt
 
 define COMMON_CONSTRAINTS_TEMP_COMMENT


### PR DESCRIPTION
Prior art: https://github.com/openedx/enterprise-access/pull/919/files

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
