### PR TITLE
feat: enabling easy theme translations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,8 @@ fake_translations: extract_translations dummy_translations compile_translations 
 
 pull_translations:
 	find credentials/conf/locale -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
-	atlas pull $(ATLAS_OPTIONS) translations/credentials/credentials/conf/locale:credentials/conf/locale
+	atlas pull $(ATLAS_OPTIONS) translations/credentials/credentials/conf/locale:credentials/conf/locale \
+		$(ATLAS_EXTRA_SOURCES)
 	python manage.py compilemessages
 
 	@echo "Translations have been pulled via Atlas and compiled."


### PR DESCRIPTION
making it easy for local configuration to  pull in extra configured translations, such as credentials-themes or any other plug-ins.

**Run JavaScript tests locally with Karma**

There is work being done on a fix to get Karma to run in CI. Until then, however, contributors are required to run these tests locally.

- [ ] Make sure you are inside the devstack container
- [ ] Run `make test-karma`
- [ ] All tests pass
