### PR TITLE
fix(VC): use URL safe encoding for the status list

### DIFF
--- a/credentials/apps/verifiable_credentials/composition/status_list.py
+++ b/credentials/apps/verifiable_credentials/composition/status_list.py
@@ -155,5 +155,5 @@ def regenerate_encoded_status_sequence(issuer_id):
         status_list[index] = 1
 
     gzip_data = gzip.compress(status_list)
-    base64_data = base64.b64encode(gzip_data)
+    base64_data = base64.urlsafe_b64encode(gzip_data).rstrip(b"=")
     return base64_data.decode("utf-8")

--- a/credentials/apps/verifiable_credentials/composition/tests/test_status_list.py
+++ b/credentials/apps/verifiable_credentials/composition/tests/test_status_list.py
@@ -25,7 +25,9 @@ class StatusListCompositionTestCase(TestCase):
     def test_regenerate_encoded_status_sequence(self, mock_get_revoked_indices):
         mock_get_revoked_indices.return_value = [1, 3, 5]
         result = regenerate_encoded_status_sequence("test")
-        decoded_data = base64.b64decode(result)
+        # Add padding back for urlsafe_b64decode
+        padded_result = result + "=" * (-len(result) % 4)
+        decoded_data = base64.urlsafe_b64decode(padded_result)
         decompressed_data = gzip.decompress(decoded_data)
         status_list = bytearray(decompressed_data)
 


### PR DESCRIPTION
Fix for the issue reported in this [Discuss thread](https://discuss.openedx.org/t/verifiable-credentials-qr-code-scan-issue-stuck-at-credential-storage-step/18349/6).
Update Base64 encoding to the URL-safe format that is supported by the latest versions of the LC wallet.