### PR TITLE
chore(teak): backport fixes for verifiable credentials compatibility

### DIFF
--- a/credentials/apps/verifiable_credentials/composition/open_badges.py
+++ b/credentials/apps/verifiable_credentials/composition/open_badges.py
@@ -18,7 +18,7 @@ class AchievementSchema(serializers.Serializer):  # pylint: disable=abstract-met
 
     TYPE = "Achievement"
 
-    id = serializers.CharField(source="user_credential.uuid")
+    id = serializers.UUIDField(source="user_credential.uuid", format="urn")
     type = serializers.CharField(default=TYPE)
     name = serializers.CharField(source="credential_name")
     description = serializers.CharField(source="credential_description")

--- a/credentials/apps/verifiable_credentials/composition/status_list.py
+++ b/credentials/apps/verifiable_credentials/composition/status_list.py
@@ -155,5 +155,5 @@ def regenerate_encoded_status_sequence(issuer_id):
         status_list[index] = 1
 
     gzip_data = gzip.compress(status_list)
-    base64_data = base64.b64encode(gzip_data)
+    base64_data = base64.urlsafe_b64encode(gzip_data).rstrip(b"=")
     return base64_data.decode("utf-8")

--- a/credentials/apps/verifiable_credentials/composition/tests/test_open_badges.py
+++ b/credentials/apps/verifiable_credentials/composition/tests/test_open_badges.py
@@ -82,7 +82,7 @@ class TestOpenBadgesDataModel:
         """
         Credential Subject Achievement `id` property.
         """
-        expected_id = str(program_issuance_line.user_credential.uuid)
+        expected_id = f"urn:uuid:{program_issuance_line.user_credential.uuid}"
 
         composed_obv3 = OpenBadgesDataModel(program_issuance_line).data
 

--- a/credentials/apps/verifiable_credentials/composition/tests/test_status_list.py
+++ b/credentials/apps/verifiable_credentials/composition/tests/test_status_list.py
@@ -25,7 +25,9 @@ class StatusListCompositionTestCase(TestCase):
     def test_regenerate_encoded_status_sequence(self, mock_get_revoked_indices):
         mock_get_revoked_indices.return_value = [1, 3, 5]
         result = regenerate_encoded_status_sequence("test")
-        decoded_data = base64.b64decode(result)
+        # Add padding back for urlsafe_b64decode
+        padded_result = result + "=" * (-len(result) % 4)
+        decoded_data = base64.urlsafe_b64decode(padded_result)
         decompressed_data = gzip.decompress(decoded_data)
         status_list = bytearray(decompressed_data)
 

--- a/requirements/all.txt
+++ b/requirements/all.txt
@@ -123,7 +123,7 @@ defusedxml==0.7.1
     #   -r requirements/production.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.3
+openedx-didkit==0.3.5
     # via
     #   -r requirements/dev.txt
     #   -r requirements/production.txt

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,7 +11,7 @@
 
 bleach
 coreapi
-didkit
+openedx-didkit
 django
 django-config-models                # Configuration models for Django allowing config management with auditing
 django-cors-headers

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -49,7 +49,7 @@ defusedxml==0.7.1
     # via
     #   python3-openid
     #   social-auth-core
-didkit==0.3.3
+openedx-didkit==0.3.5
     # via -r requirements/base.in
 django==4.2.20
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -98,7 +98,7 @@ defusedxml==0.7.1
     #   -r requirements/test.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.3
+openedx-didkit==0.3.5
     # via -r requirements/test.txt
 dill==0.4.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -75,7 +75,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.3
+openedx-didkit==0.3.5
     # via -r requirements/base.txt
 django==4.2.20
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -91,7 +91,7 @@ defusedxml==0.7.1
     #   -r requirements/base.txt
     #   python3-openid
     #   social-auth-core
-didkit==0.3.3
+openedx-didkit==0.3.5
     # via -r requirements/base.txt
 dill==0.4.0
     # via pylint


### PR DESCRIPTION
## Description

Backport fixes for https://github.com/openedx/credentials/issues/2956

- Update Base64 encoding to the URL-safe format that is supported by the latest versions of the LC wallet.
- Update OBV3 achievement id format to be urn compatible.
- Update the didkit package to the openedx fork with the updated DIDKit Core Rust library.


## Other information
As Teak release is already past EOL, the main purpose of this backport is to allow applying patches directly to the Tutor v20.0.0 using `credentials-dockerfile-post-git-checkout`([Link](https://github.com/overhangio/tutor-credentials/blob/v20.0.0/tutorcredentials/templates/credentials/build/credentials/Dockerfile?rgh-link-date=2026-04-02T09%3A41%3A46Z#L51))