### PR TITLE
refactor(badges): prevent orphaned BadgeProgress creation

### DIFF
--- a/credentials/apps/badges/models.py
+++ b/credentials/apps/badges/models.py
@@ -126,7 +126,15 @@ class BadgeTemplate(AbstractCredential):
         """
         Determines a completion progress for user.
         """
-        progress = BadgeProgress.for_user(username=username, template_id=self.id)
+        progress = BadgeProgress.for_user(
+            username=username, 
+            template_id=self.id,
+            create=False
+        )
+        
+        if not progress:
+            return 0.00
+
         return progress.ratio
 
     def is_completed(self, username: str) -> bool:
@@ -274,7 +282,15 @@ class BadgeRequirement(models.Model):
         Checks if the group is fulfilled.
         """
 
-        progress = BadgeProgress.for_user(username=username, template_id=template.id)
+        progress = BadgeProgress.for_user(
+            username=username, 
+            template_id=template.id,
+            create=False
+        )
+        
+        if not progress:
+            return False
+
         requirements = cls.objects.filter(template=template, blend=group)
         fulfilled_requirements = requirements.filter(fulfillments__progress=progress).count()
 
@@ -509,13 +525,16 @@ class BadgeProgress(models.Model):
         return f"BadgeProgress:{self.username}"
 
     @classmethod
-    def for_user(cls, *, username, template_id):
+    def for_user(cls, *, username, template_id, create=True):
         """
         Service shortcut.
         """
 
-        progress, __ = cls.objects.get_or_create(username=username, template_id=template_id)
-        return progress
+        if create:
+            progress, __ = cls.objects.get_or_create(username=username, template_id=template_id)
+            return progress
+        else:
+            return cls.objects.filter(username=username, template_id=template_id).first()
 
     @property
     def ratio(self) -> float:

--- a/credentials/apps/badges/models.py
+++ b/credentials/apps/badges/models.py
@@ -127,7 +127,7 @@ class BadgeTemplate(AbstractCredential):
         Determines a completion progress for user.
         """
         progress = BadgeProgress.for_user(username=username, template_id=self.id)
-        
+
         if not progress:
             return 0.00
 
@@ -279,7 +279,7 @@ class BadgeRequirement(models.Model):
         """
 
         progress = BadgeProgress.for_user(username=username, template_id=template.id)
-        
+
         if not progress:
             return False
 
@@ -520,11 +520,11 @@ class BadgeProgress(models.Model):
     def for_user(cls, *, username, template_id, create_if_absent=False):
         """
         Retrieve or create a BadgeProgress record for a user and template.
-        
+
         This method follows a lazy-load pattern to control when BadgeProgress records
         are created. Use create_if_absent=False for read-only operations to avoid
         creating orphaned records.
-        
+
         Args:
             username: The username of the user to get or create progress for.
             template_id: The ID of the BadgeTemplate to track progress for.
@@ -536,7 +536,7 @@ class BadgeProgress(models.Model):
         if create_if_absent:
             progress, __ = cls.objects.get_or_create(username=username, template_id=template_id)
             return progress
-        
+
         return cls.objects.filter(username=username, template_id=template_id).first()
 
     @property

--- a/credentials/apps/badges/models.py
+++ b/credentials/apps/badges/models.py
@@ -126,11 +126,7 @@ class BadgeTemplate(AbstractCredential):
         """
         Determines a completion progress for user.
         """
-        progress = BadgeProgress.for_user(
-            username=username, 
-            template_id=self.id,
-            create=False
-        )
+        progress = BadgeProgress.for_user(username=username, template_id=self.id)
         
         if not progress:
             return 0.00
@@ -223,7 +219,7 @@ class BadgeRequirement(models.Model):
         Returns: (bool) if progression happened
         """
         template_id = self.template.id
-        progress = BadgeProgress.for_user(username=username, template_id=template_id)
+        progress = BadgeProgress.for_user(username=username, template_id=template_id, create_if_absent=True)
         fulfillment, created = Fulfillment.objects.get_or_create(progress=progress, requirement=self, blend=self.blend)
 
         if created:
@@ -282,11 +278,7 @@ class BadgeRequirement(models.Model):
         Checks if the group is fulfilled.
         """
 
-        progress = BadgeProgress.for_user(
-            username=username, 
-            template_id=template.id,
-            create=False
-        )
+        progress = BadgeProgress.for_user(username=username, template_id=template.id)
         
         if not progress:
             return False
@@ -525,16 +517,27 @@ class BadgeProgress(models.Model):
         return f"BadgeProgress:{self.username}"
 
     @classmethod
-    def for_user(cls, *, username, template_id, create=True):
+    def for_user(cls, *, username, template_id, create_if_absent=False):
         """
-        Service shortcut.
+        Retrieve or create a BadgeProgress record for a user and template.
+        
+        This method follows a lazy-load pattern to control when BadgeProgress records
+        are created. Use create_if_absent=False for read-only operations to avoid
+        creating orphaned records.
+        
+        Args:
+            username: The username of the user to get or create progress for.
+            template_id: The ID of the BadgeTemplate to track progress for.
+            create_if_absent: Whether to create a new record if one doesn't exist.
+                - If True: Creates a new BadgeProgress record if needed
+                - If False: Returns None if the record doesn't exist, without creating
         """
 
-        if create:
+        if create_if_absent:
             progress, __ = cls.objects.get_or_create(username=username, template_id=template_id)
             return progress
-        else:
-            return cls.objects.filter(username=username, template_id=template_id).first()
+        
+        return cls.objects.filter(username=username, template_id=template_id).first()
 
     @property
     def ratio(self) -> float:

--- a/credentials/apps/badges/signals/handlers.py
+++ b/credentials/apps/badges/signals/handlers.py
@@ -50,7 +50,7 @@ def handle_requirement_fulfilled(sender, username, **kwargs):
     """
     On user's Badge progression (completion).
     """
-    BadgeProgress.for_user(username=username, template_id=sender.template.id).progress()
+    BadgeProgress.for_user(username=username, template_id=sender.template.id, create_if_absent=True).progress()
 
 
 @receiver(BADGE_REQUIREMENT_REGRESSED)
@@ -58,7 +58,7 @@ def handle_requirement_regressed(sender, username, **kwargs):
     """
     On user's Badge regression (incompletion).
     """
-    BadgeProgress.for_user(username=username, template_id=sender.template.id).regress()
+    BadgeProgress.for_user(username=username, template_id=sender.template.id, create_if_absent=True).regress()
 
 
 @receiver(BADGE_PROGRESS_COMPLETE)

--- a/credentials/apps/badges/tests/test_services.py
+++ b/credentials/apps/badges/tests/test_services.py
@@ -421,7 +421,7 @@ class TestProcessRequirements(TestCase):
         )
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement).count(), 1)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     def test_course_a_or_b_completion(self):
         """
@@ -457,7 +457,7 @@ class TestProcessRequirements(TestCase):
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_a).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     def test_course_a_or_b_or_c_completion(self):
         """
@@ -506,7 +506,7 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_a).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 0)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     def test_course_a_or_completion(self):
         """
@@ -529,7 +529,7 @@ class TestProcessRequirements(TestCase):
         )
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement).count(), 1)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     def test_course_a_or_b_and_c_completion(self):
         """
@@ -572,7 +572,7 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_a).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 1)
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
         DataRule.objects.create(
             requirement=requirement_b,
@@ -587,7 +587,7 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 1)
 
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     def test_course_a_or_b_and_c_or_d_completion(self):
         """
@@ -639,7 +639,7 @@ class TestProcessRequirements(TestCase):
             value="D",
         )
 
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
 
@@ -647,7 +647,7 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_d).count(), 0)
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
         DataRule.objects.create(
             requirement=requirement_c,
@@ -661,7 +661,7 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_d).count(), 0)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
 
 class TestIdentifyUser(TestCase):
@@ -720,7 +720,7 @@ class TestProcessEvent(TestCase):
     def test_process_event_passing(self):
         event_payload = COURSE_PASSING_DATA
         process_event(sender=self.sender, kwargs=event_payload)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     def test_process_event_not_passing(self):
         event_payload = CoursePassingStatusData(
@@ -733,7 +733,7 @@ class TestProcessEvent(TestCase):
             ),
         )
         process_event(sender=self.sender, kwargs=event_payload)
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id).completed)
+        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
 
     @patch.object(BadgeProgress, "regress", mock_progress_regress)
     def test_process_event_not_found(self):

--- a/credentials/apps/badges/tests/test_services.py
+++ b/credentials/apps/badges/tests/test_services.py
@@ -421,7 +421,11 @@ class TestProcessRequirements(TestCase):
         )
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement).count(), 1)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     def test_course_a_or_b_completion(self):
         """
@@ -457,7 +461,11 @@ class TestProcessRequirements(TestCase):
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_a).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     def test_course_a_or_b_or_c_completion(self):
         """
@@ -506,7 +514,11 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_a).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 0)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     def test_course_a_or_completion(self):
         """
@@ -529,7 +541,11 @@ class TestProcessRequirements(TestCase):
         )
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement).count(), 1)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     def test_course_a_or_b_and_c_completion(self):
         """
@@ -572,7 +588,11 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_a).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 1)
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertFalse(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
         DataRule.objects.create(
             requirement=requirement_b,
@@ -587,7 +607,11 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 1)
 
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     def test_course_a_or_b_and_c_or_d_completion(self):
         """
@@ -639,7 +663,11 @@ class TestProcessRequirements(TestCase):
             value="D",
         )
 
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertFalse(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
         process_requirements(COURSE_PASSING_EVENT, "test_username", COURSE_PASSING_DATA)
 
@@ -647,7 +675,11 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_d).count(), 0)
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertFalse(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
         DataRule.objects.create(
             requirement=requirement_c,
@@ -661,7 +693,11 @@ class TestProcessRequirements(TestCase):
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_b).count(), 0)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_c).count(), 1)
         self.assertEqual(Fulfillment.objects.filter(requirement=requirement_d).count(), 0)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
 
 class TestIdentifyUser(TestCase):
@@ -720,7 +756,11 @@ class TestProcessEvent(TestCase):
     def test_process_event_passing(self):
         event_payload = COURSE_PASSING_DATA
         process_event(sender=self.sender, kwargs=event_payload)
-        self.assertTrue(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertTrue(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     def test_process_event_not_passing(self):
         event_payload = CoursePassingStatusData(
@@ -733,7 +773,11 @@ class TestProcessEvent(TestCase):
             ),
         )
         process_event(sender=self.sender, kwargs=event_payload)
-        self.assertFalse(BadgeProgress.for_user(username="test_username", template_id=self.badge_template.id, create_if_absent=True).completed)
+        self.assertFalse(
+            BadgeProgress.for_user(
+                username="test_username", template_id=self.badge_template.id, create_if_absent=True
+            ).completed
+        )
 
     @patch.object(BadgeProgress, "regress", mock_progress_regress)
     def test_process_event_not_found(self):


### PR DESCRIPTION
## Description

The badge processing system is creating an excessive number of orphaned `BadgeProgress` records (records without associated `Fulfillment` data) due to a critical logic flaw. With 140+ active badge templates, this issue is significantly amplified, creating thousands of unnecessary database records daily.

## Changes

An optional `create` parameter (default True) was added to the `for_user()` method. This parameter controls whether the method should create a new BadgeProgress record when it doesn't exist, or simply retrieve it if it already exists.

Previously, the method always created a record using `get_or_create()`, with no option to just query. This meant any code that called this method, even just to check if a record existed, would end up automatically creating one.

## How to test

1. Configure Badge Template:
   - Navigate to the badge template admin panel
   - Enable "Is active" checkbox
   - In Badge requirements section, add an EVENT_TYPE:
     - `org.openedx.learning.course.passing.status.updated.v1`
     - `org.openedx.learning.ccx.course.passing.status.updated.v1`

2. Create Badge Requirements:
   - Go to Badge requirement admin panel
   - Add Data rules for the requirement (e.g., `is_passing = true`)

3. Create a test course in Studio:
   - Create a new course with grading enabled
   - Add a subsection with grading enabled
   - Add a problem worth points that leads to passing grade
   - Enroll and complete course:

4. Enroll test student in course
   - Answer problems to meet passing grade
   - Verify "Passing" status is displayed

## Before the changes

At the time of testing, there are 8 active badge templates, of which only 4 meet the rules for a completed course, yet 8 badgeProgress records are generated.

<img width="2419" height="763" alt="image" src="https://github.com/user-attachments/assets/ec5da17c-0089-4849-abf4-40a57e574b57" />

## After the changes

It only creates in badgeProgress the necessary records—those that meet the badge template rules.

<img width="2419" height="907" alt="image" src="https://github.com/user-attachments/assets/5f37ed98-7973-47e2-9d75-0ee4827debe9" />
