### PR TITLE
fix: clear full_name during user retirement

### DIFF
--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -691,3 +691,17 @@ class UsernameReplacementViewTests(JwtMixin, APITestCase):
         response = self.call_api(self.service_user, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, expected_response)
+
+    def test_clears_full_name_for_replaced_user(self):
+        """Verify username replacement clears PII fields (matching LMS retirement pattern with empty strings)."""
+        user = UserFactory(full_name="Jane Example", first_name="Jane", last_name="Example")
+        new_username = f"{user.username}_retired"
+
+        response = self.call_api(self.service_user, {"username_mappings": [{user.username: new_username}]})
+
+        self.assertEqual(response.status_code, 200)
+        user.refresh_from_db()
+        self.assertEqual(user.username, new_username)
+        self.assertEqual(user.full_name, "")
+        self.assertEqual(user.first_name, "")
+        self.assertEqual(user.last_name, "")

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -263,9 +263,14 @@ class UsernameReplacementView(APIView):
             with transaction.atomic():
                 num_rows_changed = 0
                 for model, column in replacement_locations:
-                    num_rows_changed += model.objects.filter(**{column: current_username}).update(
-                        **{column: new_username}
-                    )
+                    update_kwargs = {column: new_username}
+                    # Clear PII fields for user retirement to match LMS retirement pattern
+                    # (empty strings, not "redacted" - that's used in cleanup phase later)
+                    if model._meta.label_lower == "core.user" and column == "username":
+                        update_kwargs["full_name"] = ""
+                        update_kwargs["first_name"] = ""
+                        update_kwargs["last_name"] = ""
+                    num_rows_changed += model.objects.filter(**{column: current_username}).update(**update_kwargs)
         except Exception as exc:
             log.exception(
                 "Unable to change username from %s to %s. Failed on table %s because %s",

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -265,7 +265,6 @@ class UsernameReplacementView(APIView):
                 for model, column in replacement_locations:
                     update_kwargs = {column: new_username}
                     # Clear PII fields for user retirement to match LMS retirement pattern
-                    # (empty strings, not "redacted" - that's used in cleanup phase later)
                     if model._meta.label_lower == "core.user" and column == "username":
                         update_kwargs["full_name"] = ""
                         update_kwargs["first_name"] = ""


### PR DESCRIPTION
## Description
This PR fixes an issue where the Credentials service user retirement flow did not fully anonymize retired users full name.

### Changes
- Clear the `full_name` field during the user retirement process.

### Ticket
[LP-959](https://2u-internal.atlassian.net/browse/LP-959)