### PR TITLE
fix(badges): use current timestamp for Credly badge issuance date

### DIFF
--- a/credentials/apps/badges/issuers.py
+++ b/credentials/apps/badges/issuers.py
@@ -6,6 +6,7 @@ from datetime import datetime
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
+from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from credentials.apps.badges.accredible.api_client import AccredibleAPIClient
@@ -152,7 +153,7 @@ class CredlyBadgeTemplateIssuer(BadgeTemplateIssuer):
             issued_to_first_name=(user.first_name or user.username),
             issued_to_last_name=(user.last_name or user.username),
             badge_template_id=str(badge_template.uuid),
-            issued_at=badge_template.created.strftime("%Y-%m-%d %H:%M:%S %z"),
+            issued_at=timezone.now().strftime("%Y-%m-%d %H:%M:%S %z"),
         )
 
         try:


### PR DESCRIPTION
## Description
Updates the `issued_at` timestamp sent to Credly when issuing a badge.

Previously, `issued_at` was set to `badge_template.created` (the creation date of the badge template). This caused badges to be backdated to when the template was created rather than showing the date when the badge was actually awarded to the user.

## Testing Instructions
1. Award a Credly badge to a user where the badge template was created in the past.
2. Check the issued badge details on Credly to confirm `Issued on` matches the current timestamp instead of the template creation date.