### PR TITLE
fix: clear email during user retirement

### DIFF
--- a/credentials/apps/api/v2/tests/test_views.py
+++ b/credentials/apps/api/v2/tests/test_views.py
@@ -694,7 +694,7 @@ class UsernameReplacementViewTests(JwtMixin, APITestCase):
 
     def test_clears_full_name_for_replaced_user(self):
         """Verify username replacement clears PII fields (matching LMS retirement pattern with empty strings)."""
-        user = UserFactory(full_name="Jane Example", first_name="Jane", last_name="Example")
+        user = UserFactory(full_name="Jane Example", first_name="Jane", last_name="Example", email="jane@example.com")
         new_username = f"{user.username}_retired"
 
         response = self.call_api(self.service_user, {"username_mappings": [{user.username: new_username}]})
@@ -705,3 +705,4 @@ class UsernameReplacementViewTests(JwtMixin, APITestCase):
         self.assertEqual(user.full_name, "")
         self.assertEqual(user.first_name, "")
         self.assertEqual(user.last_name, "")
+        self.assertEqual(user.email, "")

--- a/credentials/apps/api/v2/views.py
+++ b/credentials/apps/api/v2/views.py
@@ -269,13 +269,14 @@ class UsernameReplacementView(APIView):
                         update_kwargs["full_name"] = ""
                         update_kwargs["first_name"] = ""
                         update_kwargs["last_name"] = ""
+                        update_kwargs["email"] = ""
                     num_rows_changed += model.objects.filter(**{column: current_username}).update(**update_kwargs)
         except Exception as exc:
             log.exception(
                 "Unable to change username from %s to %s. Failed on table %s because %s",
                 current_username,
                 new_username,
-                model.__class__.__name__,
+                model._meta.label_lower,
                 exc,
             )
             return False


### PR DESCRIPTION
## Description
This PR fixes an issue where the Credentials service user retirement flow did not fully anonymize retired users email.

## Changes
Clear the email field during the user retirement process.
## Ticket
[LP-959](https://2u-internal.atlassian.net/browse/LP-959)
