### PR TITLE
fix: use PEP 508 syntax for credentials-themes requirement

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -55,4 +55,4 @@ xss-utils
 
 # TODO Install in configuration
 git+https://github.com/openedx/event-bus-redis.git@v0.5.0
-git+https://github.com/openedx/credentials-themes.git@0.5.6#egg=edx_credentials_themes==0.5.6
+edx_credentials_themes @ git+https://github.com/openedx/credentials-themes.git@0.5.6


### PR DESCRIPTION
## Description

The weekly automated "Upgrade Requirements" workflow has failed on every scheduled run since 2026-02-24 (last success: 2026-02-17, which produced #2959). Each run crashes in `make upgrade` on the very first `pip-compile` invocation:

```
pip._internal.exceptions.InvalidEggFragment: <InvalidEggFragment: invalid-egg-fragment>
```

The cause is this line in `requirements/base.in`:

```
git+https://github.com/openedx/credentials-themes.git@0.5.6#egg=edx_credentials_themes==0.5.6
```

An `#egg=` fragment may only contain a bare project name; the `==0.5.6` version specifier was never valid. Older pip only warned about it, but the workflow installs the latest pip, and pip >= 26 turned this long-deprecated pattern into a hard error — so `pip-compile` crashes at the parsing stage before resolving anything.

This PR switches the line to a PEP 508 direct reference
Verified with pip 26.1.2: the old line reproduces the exact `InvalidEggFragment` failure from the workflow logs, the new line parses correctly to `edx_credentials_themes`.

## Impact

Once merged, the next scheduled bot run will succeed again and open a fresh requirements-upgrade PR. That will also supersede #2959, which is currently unmergeable because its pinned `virtualenv==20.37.0` has since been deleted from PyPI.

Note: the workflow's failure notifications go to a 2U-internal OpsGenie address, which is likely why 6+ months of weekly failures went unnoticed.
